### PR TITLE
Remove structure_site table, add file-based coord matching, download_structures writes to DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,29 @@
 # Скопируй этот файл в .env и заполни свои ключи
 # cp .env.example .env
 
-# Materials Project API (бесплатно)
-# Получить: https://materialsproject.org → профиль → API Keys
-MP_API_KEY=
+# ── База данных PostgreSQL ────────────────────────────────────────────────────
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=crystal_lattice_db
 
-# Anthropic API (платный, Claude AI)
+# ── AI-провайдер для обогащения ───────────────────────────────────────────────
+# Выбор: gigachat | claude | auto (auto = GigaChat → Claude fallback)
+AI_PROVIDER=auto
+
+# GigaChat (Сбер) — бесплатный тариф для физлиц
+# Получить credentials: https://developers.sber.ru/studio/workspaces → проект GigaChat API
+# Scope: GIGACHAT_API_PERS (физлицо) или GIGACHAT_API_CORP (корпоратив)
+GIGACHAT_CREDENTIALS=
+GIGACHAT_SCOPE=GIGACHAT_API_PERS
+GIGACHAT_MODEL=GigaChat
+
+# Claude (Anthropic) — платный
 # Получить: https://console.anthropic.com → API Keys
 ANTHROPIC_API_KEY=
 
-# MySQL (настрой под свою установку)
-DB_HOST=localhost
-DB_USER=root
-DB_PASSWORD=root
-DB_NAME=crystal_lattice_db
+# ── Внешние источники структур ────────────────────────────────────────────────
+# Materials Project API (бесплатно)
+# Получить: https://materialsproject.org → профиль → API Keys
+MP_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ AI_PROVIDER=auto
 # Scope: GIGACHAT_API_PERS (физлицо) или GIGACHAT_API_CORP (корпоратив)
 GIGACHAT_CREDENTIALS=
 GIGACHAT_SCOPE=GIGACHAT_API_PERS
-GIGACHAT_MODEL=GigaChat
+GIGACHAT_MODEL=GigaChat-2-Max
 
 # Claude (Anthropic) — платный
 # Получить: https://console.anthropic.com → API Keys

--- a/cris/core/ml_predict.py
+++ b/cris/core/ml_predict.py
@@ -1,0 +1,188 @@
+"""
+Предсказание типа кристаллической решётки через CatBoost + KDE-векторы.
+
+Используется из main.py после coordinate-match, результат пишется
+в recognition_result с method="CATBOOST".
+
+Пример:
+    from cris.core.ml_predict import predict_catboost
+    results = predict_catboost(normalized_coords)
+    # [{"class": "cubic_f", "lattice_type_id": 8, "confidence": 0.87}, ...]
+"""
+import io
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy.stats import gaussian_kde
+
+from cris.logger import logger
+
+# ── Пути к модели ─────────────────────────────────────────────────────────────
+_ROOT = Path(__file__).parent.parent.parent
+_DEFAULT_MODEL = _ROOT / "ML" / "CatBoost" / "catboost_lattice.cbm"
+
+# ── Маппинг классов модели → name_en в таблице lattice_type ──────────────────
+# Модель обучена на подтипах Браве-решётки; все cubic_* → "cubic" и т.д.
+_CLASS_TO_LATTICE_EN: dict[str, str] = {
+    "cubic_f":   "cubic",
+    "cubic_i":   "cubic",
+    "cubic_p":   "cubic",
+    "hex_p":     "hexagonal",
+    "trig_r":    "rhombohedral",
+    "tetra_p":   "tetragonal",
+    "tetra_i":   "tetragonal",
+    "ortho_p":   "orthorhombic",
+    "ortho_i":   "orthorhombic",
+    "ortho_f":   "orthorhombic",
+    "ortho_c":   "orthorhombic",
+    "mono_p":    "monoclinic",
+    "mono_c":    "monoclinic",
+    "triclinic": "triclinic",
+}
+
+
+def _kde_array_1000(distances_counter: dict) -> np.ndarray:
+    """KDE-вектор на сетке 1000 точек [0, 2] — формат, совместимый с моделью."""
+    distances = []
+    for dist, count in distances_counter.items():
+        distances.extend([dist] * int(count))
+    arr = np.array(distances, dtype=float)
+    if len(arr) < 2:
+        return np.zeros(1000)
+    kde = gaussian_kde(arr, bw_method=0.1)
+    x_grid = np.linspace(0, 2, 1000)
+    return kde.evaluate(x_grid)
+
+
+def _coords_to_feature_vector(normalized_coords: list) -> Optional[np.ndarray]:
+    """
+    Список [label, x, y, z] → усреднённый KDE-вектор 1000-dim.
+    Подавляет print()-вывод из get_lattice_vectors3.
+    """
+    try:
+        from cris.core.vectors import get_lattice_vectors3
+
+        # Подавляем print() внутри get_lattice_vectors3
+        _old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            vectors_dict = get_lattice_vectors3(normalized_coords)
+        finally:
+            sys.stdout = _old_stdout
+
+        ion_arrays = []
+        for distances in vectors_dict.values():
+            arr = _kde_array_1000(dict(Counter(distances)))
+            ion_arrays.append(arr)
+
+        if not ion_arrays:
+            return None
+        return np.mean(ion_arrays, axis=0)
+    except Exception as e:
+        logger.warning("ml_predict: failed to compute feature vector: {}", e)
+        return None
+
+
+def _load_model(model_path: Path):
+    """Ленивая загрузка модели с понятным сообщением об ошибке."""
+    try:
+        from catboost import CatBoostClassifier
+        m = CatBoostClassifier()
+        m.load_model(str(model_path))
+        return m
+    except ImportError:
+        logger.warning("ml_predict: catboost not installed, skipping ML prediction")
+        return None
+    except Exception as e:
+        logger.warning("ml_predict: cannot load model {}: {}", model_path, e)
+        return None
+
+
+def predict_catboost(
+    normalized_coords: list,
+    model_path: Path = _DEFAULT_MODEL,
+    top_k: int = 3,
+) -> list[dict]:
+    """
+    Предсказывает тип решётки через CatBoost.
+
+    Args:
+        normalized_coords: список [label, x, y, z] — уже нормализованные
+        model_path:        путь к .cbm файлу
+        top_k:             сколько топ-классов вернуть
+
+    Returns:
+        Список словарей (отсортированных по убыванию confidence):
+        [{"class": "cubic_f", "lattice_name": "cubic",
+          "lattice_type_id": None, "confidence": 0.87}, ...]
+        lattice_type_id заполняется отдельно через resolve_lattice_ids().
+    """
+    if not model_path.exists():
+        logger.debug("ml_predict: model file not found: {}", model_path)
+        return []
+
+    model = _load_model(model_path)
+    if model is None:
+        return []
+
+    feat = _coords_to_feature_vector(normalized_coords)
+    if feat is None:
+        return []
+
+    if len(feat) != len(model.feature_names_):
+        logger.warning(
+            "ml_predict: feature size mismatch (got {}, need {})",
+            len(feat), len(model.feature_names_)
+        )
+        return []
+
+    proba  = model.predict_proba(feat.reshape(1, -1))[0]
+    classes = model.classes_
+
+    top_indices = np.argsort(proba)[::-1][:top_k]
+    results = []
+    for i in top_indices:
+        cls_name = classes[i]
+        results.append({
+            "class":           cls_name,
+            "lattice_name":    _CLASS_TO_LATTICE_EN.get(cls_name, cls_name),
+            "lattice_type_id": None,   # заполнит resolve_lattice_ids()
+            "confidence":      round(float(proba[i]), 4),
+        })
+
+    logger.debug("CatBoost prediction: top={} conf={}", results[0]["class"], results[0]["confidence"])
+    return results
+
+
+def resolve_lattice_ids(predictions: list[dict]) -> list[dict]:
+    """
+    Заполняет lattice_type_id в каждом предсказании,
+    делая один запрос к БД для уникальных имён.
+    """
+    if not predictions:
+        return predictions
+
+    from cris.db.connection import get_cursor
+
+    unique_names = {p["lattice_name"] for p in predictions}
+    name_to_id: dict[str, int] = {}
+    try:
+        with get_cursor() as cur:
+            for name in unique_names:
+                cur.execute(
+                    "SELECT id FROM lattice_type WHERE name_en = %s LIMIT 1",
+                    (name,)
+                )
+                row = cur.fetchone()
+                if row:
+                    name_to_id[name] = row[0]
+    except Exception as e:
+        logger.warning("resolve_lattice_ids failed: {}", e)
+
+    for p in predictions:
+        p["lattice_type_id"] = name_to_id.get(p["lattice_name"])
+
+    return predictions

--- a/cris/core/spectrum.py
+++ b/cris/core/spectrum.py
@@ -1,5 +1,6 @@
 import os
 from collections import Counter
+from pathlib import Path
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -11,49 +12,77 @@ from cris.db.connection import get_cursor
 from cris.core.coordinates import shift_coordinates, normalize_coordinates
 from cris.core.vectors import get_lattice_vectors2
 
+_ROOT = Path(__file__).parent.parent.parent  # корень проекта
+
+
+def _parse_xyz(xyz_path: Path) -> list[list]:
+    """Парсит XYZ-файл → [[symbol, x, y, z], ...]."""
+    lines = xyz_path.read_text(encoding="utf-8").splitlines()
+    atom_count = int(lines[0].strip())
+    result = []
+    for line in lines[2:2 + atom_count]:
+        parts = line.split()
+        if len(parts) >= 4:
+            result.append([parts[0], float(parts[1]), float(parts[2]), float(parts[3])])
+    return result
+
 
 def create_all_spectrum_plots():
     """
     Строит спектры для всех эталонных структур в БД.
+    Координаты читаются из XYZ-файлов (reference_structure.xyz_path).
     """
-    lattice_list = []
     try:
         with get_cursor() as cur:
-            cur.execute("SELECT MAX(id) FROM reference_structure")
-            lattice_count = cur.fetchone()[0] or 0
-            for struct_id in range(1, lattice_count + 1):
-                cur.execute(
-                    "SELECT structure_id, fract_x, fract_y, fract_z "
-                    "FROM structure_site WHERE structure_id = %s",
-                    (struct_id,)
-                )
-                lattice = cur.fetchall()
-                if lattice:
-                    lattice_list.append(lattice)
+            cur.execute("""
+                SELECT id, xyz_path FROM reference_structure
+                WHERE xyz_path IS NOT NULL AND xyz_path != ''
+                ORDER BY id
+            """)
+            rows = cur.fetchall()
     except Exception as e:
-        print(f"Произошла ошибка: {e}")
+        print(f"Произошла ошибка при чтении БД: {e}")
+        return
 
-    for lattice in lattice_list:
-        substance_id = lattice[0][0]
+    for struct_id, xyz_rel_path in rows:
+        xyz_path = _ROOT / xyz_rel_path
+        if not xyz_path.exists():
+            print(f"XYZ не найден для structure_id={struct_id}: {xyz_path}")
+            continue
 
+        try:
+            data = _parse_xyz(xyz_path)
+        except Exception as e:
+            print(f"Ошибка парсинга {xyz_path}: {e}")
+            continue
+
+        shifted    = shift_coordinates(data)
+        normalized = normalize_coordinates(shifted)
+
+        # Преобразуем в формат, ожидаемый get_lattice_vectors2: {n: (id, x, y, z)}
         data_dict = {}
-        for i in range(len(lattice)):
-            data_dict[i + 1] = lattice[i]
-        shifted_data = shift_coordinates(data_dict.values())
-        normalized_data = normalize_coordinates(shifted_data)
+        for i, row in enumerate(normalized):
+            data_dict[i + 1] = (struct_id, row[1], row[2], row[3])
 
-        vectors = get_lattice_vectors2(normalized_data)
-        for id, ion in enumerate(vectors.keys()):
+        vectors = get_lattice_vectors2(normalized)
+        for vec_id, ion in enumerate(vectors.keys()):
             ion_coords = [float(elem) for elem in ion.split(";")]
-            plot_spectra(data=dict(Counter(vectors[ion])), ion=ion_coords, substance_id=substance_id, vector_id=id,
-                         cmap="plasma", background="#20232a")
+            plot_spectra(
+                data=dict(Counter(vectors[ion])),
+                ion=ion_coords,
+                substance_id=struct_id,
+                vector_id=vec_id,
+                cmap="plasma",
+                background="#20232a",
+            )
+
 
 def plot_spectra(data, ion, substance_id, vector_id, cmap="plasma", background="#1e1e1e", outdir="../../data/spectrum"):
     """
     Строит спектры (гистограммы) для набора расстояний между ионами.
 
-    data : list[tuple]
-        Набор кортежей с расстояниями
+    data : dict
+        Словарь {расстояние: частота}
     cmap : str
         Цветовая схема для градиента
     background : str
@@ -89,7 +118,7 @@ def plot_spectra(data, ion, substance_id, vector_id, cmap="plasma", background="
     plt.bar(unique, counts, color=colors, width=0.02, edgecolor="white", linewidth=0.6)
     if kde_values is not None:
         plt.plot(x_grid, kde_values, color='cyan', linewidth=1)
-        ax.fill_between(x_grid, kde_values, color="cyan", alpha=0.2)  # заливка под кривой
+        ax.fill_between(x_grid, kde_values, color="cyan", alpha=0.2)
 
     plt.xlabel("Расстояние между ионами")
     plt.ylabel("Интенсивность (частота)")
@@ -101,6 +130,7 @@ def plot_spectra(data, ion, substance_id, vector_id, cmap="plasma", background="
     plt.close(fig)
 
     print(f"Изображение spectrum_{substance_id}-{vector_id + 1}.png сохранено!")
+
 
 def kde_array(data):
     distances = []

--- a/cris/db/enrichment/crossref_api.py
+++ b/cris/db/enrichment/crossref_api.py
@@ -1,0 +1,70 @@
+"""
+CrossRef REST API — поиск научных статей по формуле/названию вещества.
+
+Документация: https://api.crossref.org/swagger-ui/index.html
+Ключ API не нужен. Polite pool: добавляем mailto в User-Agent.
+Rate limit: ~50 req/s в polite pool.
+"""
+import requests
+from typing import Optional
+from cris.logger import logger
+
+_BASE    = "https://api.crossref.org/works"
+_TIMEOUT = 10
+_HEADERS = {"User-Agent": "CRIS/1.0 (crystal lattice recognition; mailto:cris@research.local)"}
+
+
+def search_articles(query: str, max_results: int = 5) -> list[dict]:
+    """
+    Ищет статьи по запросу (формула, название вещества).
+
+    Возвращает список словарей:
+        {doi, title, journal, year, url, snippet}
+    """
+    params = {
+        "query": query,
+        "rows": max_results,
+        "select": "DOI,title,container-title,published,abstract,URL",
+        "filter": "has-abstract:true",
+        "sort": "relevance",
+    }
+    try:
+        r = requests.get(_BASE, params=params, headers=_HEADERS, timeout=_TIMEOUT)
+        if r.status_code != 200:
+            logger.warning("CrossRef: HTTP {} for query '{}'", r.status_code, query)
+            return []
+        items = r.json().get("message", {}).get("items", [])
+    except Exception as e:
+        logger.warning("CrossRef request failed: {} | query={}", e, query)
+        return []
+
+    results = []
+    for item in items:
+        title = (item.get("title") or [""])[0]
+        journal = (item.get("container-title") or [""])[0]
+        doi = item.get("DOI", "")
+        url = item.get("URL") or (f"https://doi.org/{doi}" if doi else "")
+        abstract = item.get("abstract", "")
+        # берём первые 300 символов абстракта как snippet
+        snippet = abstract[:300].strip() if abstract else ""
+
+        year = None
+        pub = item.get("published", {})
+        parts = pub.get("date-parts", [[]])[0]
+        if parts:
+            year = parts[0]
+
+        if not title:
+            continue
+
+        results.append({
+            "doi":     doi,
+            "title":   title,
+            "journal": journal,
+            "year":    year,
+            "url":     url,
+            "snippet": snippet,
+        })
+
+    logger.debug("CrossRef: found {} articles for '{}'", len(results), query)
+    return results

--- a/cris/db/enrichment/enricher.py
+++ b/cris/db/enrichment/enricher.py
@@ -74,11 +74,11 @@ def enrich_lattice_type(lattice_type_id: int) -> bool:
         return False
     upsert_metadata(LatticeMetadata(
         lattice_type_id=lattice_type_id,
-        discoverer=data.get("discoverer", ""),
-        discovery_year=data.get("discovery_year"),
-        discovery_context=data.get("discovery_context", ""),
+        coordination_number=data.get("coordination_number"),
+        packing_efficiency=data.get("packing_efficiency"),
+        typical_materials=data.get("typical_materials", ""),
+        applications=data.get("applications", ""),
         wiki_url=data.get("wiki_url", ""),
-        review_doi=data.get("review_doi", ""),
         notes=data.get("notes", ""),
         enriched_at=datetime.now(),
         enrichment_source="AI_SEARCH",

--- a/cris/db/enrichment/enricher.py
+++ b/cris/db/enrichment/enricher.py
@@ -1,12 +1,18 @@
 """
 Оркестратор обогащения: COD + Materials Project + AI.
 
+AI-провайдер выбирается через переменную окружения AI_PROVIDER:
+    AI_PROVIDER=gigachat   — GigaChat (Сбер), нужен GIGACHAT_CREDENTIALS
+    AI_PROVIDER=claude     — Claude (Anthropic), нужен ANTHROPIC_API_KEY
+    AI_PROVIDER=auto       — сначала GigaChat, при неудаче Claude (по умолчанию)
+
 Примеры:
     from cris.db.enrichment.enricher import enrich_lattice_type, enrich_structure
     enrich_lattice_type(lattice_type_id=8)       # кубическая
     enrich_structure(structure_id=1, formula="NaCl")
 """
 import json
+import os
 from datetime import datetime
 
 from cris.logger import logger
@@ -16,8 +22,31 @@ from cris.db.repository.structure import update_external_ids
 from cris.db.models import LatticeMetadata
 from cris.db.enrichment.cod_api import search as cod_search
 from cris.db.enrichment.mp_api import search as mp_search
-from cris.db.enrichment.ai_search import enrich_lattice_type as ai_enrich_lattice
 from cris.db.enrichment.robocrys_describer import describe_and_save
+
+# ── Выбор AI-провайдера ───────────────────────────────────────────────────────
+_AI_PROVIDER = os.getenv("AI_PROVIDER", "auto").lower()
+
+def _get_ai_enrich_fn():
+    """Возвращает функцию enrich_lattice_type нужного провайдера."""
+    if _AI_PROVIDER == "gigachat":
+        from cris.db.enrichment.gigachat_search import enrich_lattice_type
+        return enrich_lattice_type
+    if _AI_PROVIDER == "claude":
+        from cris.db.enrichment.ai_search import enrich_lattice_type
+        return enrich_lattice_type
+    # auto: пробуем GigaChat, если вернул пустой dict — Claude
+    from cris.db.enrichment import gigachat_search, ai_search
+    def _auto(name_en, name_ru):
+        result = gigachat_search.enrich_lattice_type(name_en, name_ru)
+        if result:
+            logger.debug("AI provider used: GigaChat")
+            return result
+        logger.debug("GigaChat returned nothing, falling back to Claude")
+        return ai_search.enrich_lattice_type(name_en, name_ru)
+    return _auto
+
+_ai_enrich_lattice = _get_ai_enrich_fn()
 
 
 def _log(source: str, target_type: str, target_id: int,
@@ -38,7 +67,7 @@ def enrich_lattice_type(lattice_type_id: int) -> bool:
     lt = get_lattice(lattice_type_id)
     if not lt:
         return False
-    data = ai_enrich_lattice(lt.name_en, lt.name_ru)
+    data = _ai_enrich_lattice(lt.name_en, lt.name_ru)
     if not data:
         _log("AI_SEARCH", "lattice_type", lattice_type_id,
              f"enrich {lt.name_en}", "", {}, 0, False)

--- a/cris/db/enrichment/gigachat_search.py
+++ b/cris/db/enrichment/gigachat_search.py
@@ -103,6 +103,7 @@ def describe_structure(formula: str, lattice_type: str,
 
 def describe_substance(
     formula: str,
+    name: str = "",
     lattice_type: str = "",
     properties: dict = None,
     articles: list = None,
@@ -130,9 +131,10 @@ def describe_substance(
         articles_text = "Найденные научные публикации:\n" + "\n".join(titles)
 
     lattice_ctx = f" с кристаллической решёткой типа {lattice_type}" if lattice_type else ""
+    name_ctx = f" ({name})" if name and name != formula else ""
 
     prompt = f"""Ты эксперт по материаловедению и кристаллографии.
-Вещество: {formula}{lattice_ctx}.
+Вещество: {formula}{name_ctx}{lattice_ctx}.
 {props_text}
 {articles_text}
 

--- a/cris/db/enrichment/gigachat_search.py
+++ b/cris/db/enrichment/gigachat_search.py
@@ -105,25 +105,15 @@ def describe_substance(
     formula: str,
     name: str = "",
     lattice_type: str = "",
-    properties: dict = None,
     articles: list = None,
 ) -> dict:
     """
     Генерирует структурированное описание вещества на основе собранных данных.
-    Используется substance_enricher после PubChem + CrossRef.
+    Используется substance_enricher после CrossRef + OSTI.
 
     Возвращает словарь:
         {description, applications, hazards}
     """
-    props_text = ""
-    if properties:
-        lines = []
-        for k, v in properties.items():
-            if k != "pubchem_cid":
-                lines.append(f"  {k}: {v}")
-        if lines:
-            props_text = "Известные свойства из PubChem:\n" + "\n".join(lines)
-
     articles_text = ""
     if articles:
         titles = [f"  - {a['title']} ({a.get('journal','')}, {a.get('year','')})"

--- a/cris/db/enrichment/gigachat_search.py
+++ b/cris/db/enrichment/gigachat_search.py
@@ -1,0 +1,102 @@
+"""
+AI-обогащение через GigaChat API (Сбер).
+
+Переменные окружения:
+    GIGACHAT_CREDENTIALS — строка авторизации из личного кабинета
+                           https://developers.sber.ru/studio/workspaces
+    GIGACHAT_SCOPE       — GIGACHAT_API_PERS (физлицо) или
+                           GIGACHAT_API_CORP (корпоратив), по умолчанию PERS
+    GIGACHAT_MODEL       — модель: GigaChat / GigaChat-Plus / GigaChat-Pro
+                           по умолчанию GigaChat
+"""
+import json
+import os
+from typing import Optional
+from cris.logger import logger
+
+try:
+    from gigachat import GigaChat
+    from gigachat.models import Chat, Messages, MessagesRole
+    _GIGACHAT_AVAILABLE = True
+except ImportError:
+    _GIGACHAT_AVAILABLE = False
+    logger.warning("gigachat package not installed. Run: pip install gigachat")
+
+_CREDENTIALS = os.getenv("GIGACHAT_CREDENTIALS", "")
+_SCOPE       = os.getenv("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")
+_MODEL       = os.getenv("GIGACHAT_MODEL", "GigaChat")
+_AVAILABLE   = _GIGACHAT_AVAILABLE and bool(_CREDENTIALS)
+
+
+def _ask(prompt: str, max_tokens: int = 512) -> Optional[str]:
+    """Отправляет запрос в GigaChat, возвращает текст ответа или None."""
+    if not _AVAILABLE:
+        return None
+    try:
+        payload = Chat(
+            model=_MODEL,
+            messages=[Messages(role=MessagesRole.USER, content=prompt)],
+            max_tokens=max_tokens,
+            temperature=0.3,
+        )
+        with GigaChat(
+            credentials=_CREDENTIALS,
+            scope=_SCOPE,
+            verify_ssl_certs=False,   # Сбер использует собственный CA
+        ) as giga:
+            response = giga.chat(payload)
+            return response.choices[0].message.content.strip()
+    except Exception as e:
+        logger.error("GigaChat API request failed: {}", e)
+        return None
+
+
+def enrich_lattice_type(name_en: str, name_ru: str) -> dict:
+    """
+    Запрашивает фактические данные об открытии типа решётки.
+    Возвращает словарь для lattice_metadata.
+    """
+    prompt = f"""Ты эксперт по кристаллографии. Дай фактические данные о типе кристаллической решётки
+{name_en} ({name_ru}) строго в формате JSON:
+{{
+  "discoverer": "Имя(а) первооткрывателя или 'Unknown'",
+  "discovery_year": целое число или null,
+  "discovery_context": "1-2 предложения об условиях открытия",
+  "wiki_url": "ссылка на Википедию или пустая строка",
+  "review_doi": "DOI обзорной статьи или пустая строка",
+  "notes": "1-2 интересных факта для студента"
+}}
+Отвечай ТОЛЬКО JSON-объектом без лишнего текста."""
+    raw = _ask(prompt, 500)
+    if not raw:
+        return {}
+    # GigaChat иногда оборачивает JSON в ```json ... ``` — чистим
+    raw = raw.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    try:
+        return {k: v for k, v in json.loads(raw).items() if v not in (None, "", 0)}
+    except Exception as e:
+        logger.warning("GigaChat: failed to parse JSON response: {} | raw: {}", e, raw[:200])
+        return {}
+
+
+def clarify_recognition(candidates: list[dict]) -> str:
+    """
+    Помогает разобраться, когда разные методы дали разные результаты.
+    candidates: [{"method": "KDE_RF", "lattice": "cubic FCC", "confidence": 0.87}, ...]
+    Возвращает объяснение на русском для отображения в UI.
+    """
+    prompt = f"""Система распознавания кристаллических решёток получила следующие результаты от разных методов:
+{json.dumps(candidates, ensure_ascii=False, indent=2)}
+В 2-3 предложениях объясни, какой результат скорее всего верен и почему.
+Будь краток и научен."""
+    return _ask(prompt, 300) or ""
+
+
+def describe_structure(formula: str, lattice_type: str,
+                       space_group: str, doi: str = "") -> str:
+    """Краткое описание вещества для UI после распознавания."""
+    ref = f" (DOI: {doi})" if doi else ""
+    prompt = (f"Опиши вещество {formula} с решёткой типа {lattice_type}, "
+              f"пространственная группа {space_group}{ref} в 2-3 предложениях. "
+              f"Сосредоточься на практическом значении и ключевых свойствах. Будь краток.")
+    return _ask(prompt, 250) or ""

--- a/cris/db/enrichment/gigachat_search.py
+++ b/cris/db/enrichment/gigachat_search.py
@@ -24,7 +24,7 @@ except ImportError:
 
 _CREDENTIALS = os.getenv("GIGACHAT_CREDENTIALS", "")
 _SCOPE       = os.getenv("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")
-_MODEL       = os.getenv("GIGACHAT_MODEL", "GigaChat")
+_MODEL       = os.getenv("GIGACHAT_MODEL", "GigaChat-2-Max")
 _AVAILABLE   = _GIGACHAT_AVAILABLE and bool(_CREDENTIALS)
 
 

--- a/cris/db/enrichment/gigachat_search.py
+++ b/cris/db/enrichment/gigachat_search.py
@@ -53,24 +53,23 @@ def _ask(prompt: str, max_tokens: int = 512) -> Optional[str]:
 
 def enrich_lattice_type(name_en: str, name_ru: str) -> dict:
     """
-    Запрашивает фактические данные об открытии типа решётки.
+    Запрашивает структурные и физические данные о типе решётки.
     Возвращает словарь для lattice_metadata.
     """
-    prompt = f"""Ты эксперт по кристаллографии. Дай фактические данные о типе кристаллической решётки
+    prompt = f"""Ты эксперт по кристаллографии. Дай точные структурные данные о типе кристаллической решётки
 {name_en} ({name_ru}) строго в формате JSON:
 {{
-  "discoverer": "Имя(а) первооткрывателя или 'Unknown'",
-  "discovery_year": целое число или null,
-  "discovery_context": "1-2 предложения об условиях открытия",
-  "wiki_url": "ссылка на Википедию или пустая строка",
-  "review_doi": "DOI обзорной статьи или пустая строка",
-  "notes": "1-2 интересных факта для студента"
+  "coordination_number": целое число (сколько ближайших соседей у атома),
+  "packing_efficiency": число от 0 до 1 (доля занятого объёма),
+  "typical_materials": "примеры веществ через запятую: Al, Cu, Fe...",
+  "applications": "1-2 предложения о практическом применении",
+  "wiki_url": "ссылка на англоязычную Википедию или пустая строка",
+  "notes": "1-2 интересных структурных факта"
 }}
 Отвечай ТОЛЬКО JSON-объектом без лишнего текста."""
-    raw = _ask(prompt, 500)
+    raw = _ask(prompt, 400)
     if not raw:
         return {}
-    # GigaChat иногда оборачивает JSON в ```json ... ``` — чистим
     raw = raw.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
     try:
         return {k: v for k, v in json.loads(raw).items() if v not in (None, "", 0)}
@@ -100,3 +99,57 @@ def describe_structure(formula: str, lattice_type: str,
               f"пространственная группа {space_group}{ref} в 2-3 предложениях. "
               f"Сосредоточься на практическом значении и ключевых свойствах. Будь краток.")
     return _ask(prompt, 250) or ""
+
+
+def describe_substance(
+    formula: str,
+    lattice_type: str = "",
+    properties: dict = None,
+    articles: list = None,
+) -> dict:
+    """
+    Генерирует структурированное описание вещества на основе собранных данных.
+    Используется substance_enricher после PubChem + CrossRef.
+
+    Возвращает словарь:
+        {description, applications, hazards}
+    """
+    props_text = ""
+    if properties:
+        lines = []
+        for k, v in properties.items():
+            if k != "pubchem_cid":
+                lines.append(f"  {k}: {v}")
+        if lines:
+            props_text = "Известные свойства из PubChem:\n" + "\n".join(lines)
+
+    articles_text = ""
+    if articles:
+        titles = [f"  - {a['title']} ({a.get('journal','')}, {a.get('year','')})"
+                  for a in articles[:3]]
+        articles_text = "Найденные научные публикации:\n" + "\n".join(titles)
+
+    lattice_ctx = f" с кристаллической решёткой типа {lattice_type}" if lattice_type else ""
+
+    prompt = f"""Ты эксперт по материаловедению и кристаллографии.
+Вещество: {formula}{lattice_ctx}.
+{props_text}
+{articles_text}
+
+На основе этих данных дай ответ строго в формате JSON:
+{{
+  "description": "2-3 предложения: что это за вещество, его кристаллическая структура и ключевые свойства",
+  "applications": "1-2 предложения: где применяется в науке и промышленности",
+  "hazards": "токсичность, радиоактивность, взрывоопасность или пустая строка если не опасно"
+}}
+Отвечай ТОЛЬКО JSON-объектом без лишнего текста."""
+
+    raw = _ask(prompt, 500)
+    if not raw:
+        return {}
+    raw = raw.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    try:
+        return {k: v for k, v in json.loads(raw).items() if v not in (None, "")}
+    except Exception as e:
+        logger.warning("GigaChat describe_substance: failed to parse JSON: {} | raw: {}", e, raw[:200])
+        return {}

--- a/cris/db/enrichment/osti_api.py
+++ b/cris/db/enrichment/osti_api.py
@@ -1,0 +1,71 @@
+"""
+OSTI.gov API — поиск научных публикаций Министерства энергетики США.
+
+Особенно полезен для ядерных материалов: UO2, UN, UC, PuO2 и др.
+Документация: https://www.osti.gov/api/v1
+Ключ API не нужен.
+"""
+import requests
+from typing import Optional
+from cris.logger import logger
+
+_BASE    = "https://www.osti.gov/api/v1/records"
+_TIMEOUT = 10
+_HEADERS = {"Accept": "application/json"}
+
+
+def search_articles(query: str, max_results: int = 5) -> list[dict]:
+    """
+    Ищет публикации по запросу в базе OSTI.gov.
+
+    Возвращает список словарей:
+        {doi, title, journal, year, url, snippet}
+    """
+    params = {
+        "q":              query,
+        "rows":           max_results,
+        "sort":           "score desc",
+    }
+    try:
+        r = requests.get(_BASE, params=params, headers=_HEADERS, timeout=_TIMEOUT)
+        if r.status_code != 200:
+            logger.warning("OSTI: HTTP {} for query '{}'", r.status_code, query)
+            return []
+        items = r.json()
+        if not isinstance(items, list):
+            items = items.get("records", [])
+    except Exception as e:
+        logger.warning("OSTI request failed: {} | query={}", e, query)
+        return []
+
+    results = []
+    for item in items:
+        title   = item.get("title", "").strip()
+        doi     = item.get("doi", "")
+        url     = item.get("site_url") or (f"https://doi.org/{doi}" if doi else "")
+        journal = item.get("journal_name") or item.get("publisher_name", "")
+        snippet = (item.get("description") or item.get("abstract") or "")[:300].strip()
+
+        year = None
+        pub_date = item.get("publication_date") or item.get("published_date") or ""
+        if pub_date and len(pub_date) >= 4:
+            try:
+                year = int(pub_date[:4])
+            except ValueError:
+                pass
+
+        if not title:
+            continue
+
+        results.append({
+            "doi":     doi,
+            "title":   title,
+            "journal": journal,
+            "year":    year,
+            "url":     url,
+            "snippet": snippet,
+            "source":  "OSTI",
+        })
+
+    logger.debug("OSTI: found {} articles for '{}'", len(results), query)
+    return results

--- a/cris/db/enrichment/pubchem_api.py
+++ b/cris/db/enrichment/pubchem_api.py
@@ -1,0 +1,102 @@
+"""
+PubChem REST API — получение физико-химических свойств вещества.
+
+Документация: https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest
+Ключ API не нужен, rate limit: 5 req/s.
+"""
+import requests
+from typing import Optional
+from cris.logger import logger
+
+_BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+_TIMEOUT = 10
+
+
+def _get(url: str) -> Optional[dict]:
+    try:
+        r = requests.get(url, timeout=_TIMEOUT)
+        if r.status_code == 200:
+            return r.json()
+        return None
+    except Exception as e:
+        logger.warning("PubChem request failed: {} | url={}", e, url)
+        return None
+
+
+def get_properties(formula: str) -> dict:
+    """
+    Ищет вещество по формуле, возвращает словарь физических свойств.
+
+    Возвращаемые поля (если найдены):
+        molecular_weight, melting_point, boiling_point, density,
+        color, iupac_name, hazard_class, pubchem_cid
+    """
+    # 1. Ищем CID по формуле
+    url = f"{_BASE}/compound/formula/{formula}/cids/JSON"
+    data = _get(url)
+    if not data:
+        logger.debug("PubChem: no CID for formula '{}'", formula)
+        return {}
+
+    cids = data.get("IdentifierList", {}).get("CID", [])
+    if not cids:
+        return {}
+    cid = cids[0]
+
+    # 2. Получаем свойства по CID
+    props = "MolecularWeight,IUPACName,MolecularFormula"
+    url_props = f"{_BASE}/compound/cid/{cid}/property/{props}/JSON"
+    prop_data = _get(url_props)
+
+    result: dict = {"pubchem_cid": cid}
+
+    if prop_data:
+        p = prop_data.get("PropertyTable", {}).get("Properties", [{}])[0]
+        if p.get("MolecularWeight"):
+            result["molecular_weight"] = f"{p['MolecularWeight']} г/моль"
+        if p.get("IUPACName"):
+            result["iupac_name"] = p["IUPACName"]
+
+    # 3. Получаем экспериментальные данные (температуры, плотность и пр.)
+    url_exp = f"{_BASE}/compound/cid/{cid}/JSON"
+    full_data = _get(url_exp)
+    if full_data:
+        _extract_experimental(full_data, result)
+
+    logger.debug("PubChem: got {} properties for '{}' (CID={})", len(result), formula, cid)
+    return result
+
+
+def _extract_experimental(data: dict, result: dict) -> None:
+    """Извлекает экспериментальные свойства из полного ответа PubChem."""
+    try:
+        sections = (
+            data.get("PC_Compounds", [{}])[0]
+            .get("props", [])
+        )
+        for prop in sections:
+            urn = prop.get("urn", {})
+            label = urn.get("label", "")
+            name  = urn.get("name", "")
+            value = prop.get("value", {})
+            val_str = (
+                value.get("sval")
+                or value.get("fval")
+                or value.get("ival")
+            )
+            if not val_str:
+                continue
+            val_str = str(val_str)
+
+            if label == "Melting Point" and "melting_point" not in result:
+                result["melting_point"] = val_str
+            elif label == "Boiling Point" and "boiling_point" not in result:
+                result["boiling_point"] = val_str
+            elif label == "Density" and "density" not in result:
+                result["density"] = val_str
+            elif label == "Color/Form" and "color" not in result:
+                result["color"] = val_str
+            elif label == "GHS Hazard Statements" and "hazard_ghs" not in result:
+                result["hazard_ghs"] = val_str[:200]
+    except Exception as e:
+        logger.debug("PubChem: experimental extraction error: {}", e)

--- a/cris/db/enrichment/substance_enricher.py
+++ b/cris/db/enrichment/substance_enricher.py
@@ -14,11 +14,43 @@
 from datetime import datetime
 
 from cris.logger import logger
+from cris.db.connection import get_cursor
 from cris.db.models import SubstanceInfo
 from cris.db.repository.substance import get_by_structure, upsert
 from cris.db.enrichment.crossref_api import search_articles as crossref_search
 from cris.db.enrichment.osti_api import search_articles as osti_search
 from cris.db.enrichment import gigachat_search
+
+
+def _load_crystal_properties(structure_id: int) -> dict:
+    """Загружает кристаллографические параметры из reference_structure."""
+    with get_cursor() as cur:
+        cur.execute("""
+            SELECT cell_length_a, cell_length_b, cell_length_c, cell_volume,
+                   cell_angle_alpha, cell_angle_beta, cell_angle_gamma,
+                   sg_number, sg_hall, sg_hm, cod_id
+            FROM reference_structure WHERE id = %s
+        """, (structure_id,))
+        row = cur.fetchone()
+    if not row:
+        return {}
+    _int_fields  = {"sg_number", "cod_id"}
+    _float_fields = {"cell_length_a", "cell_length_b", "cell_length_c", "cell_volume",
+                     "cell_angle_alpha", "cell_angle_beta", "cell_angle_gamma"}
+    keys = ["cell_length_a", "cell_length_b", "cell_length_c", "cell_volume",
+            "cell_angle_alpha", "cell_angle_beta", "cell_angle_gamma",
+            "sg_number", "sg_hall", "sg_hm", "cod_id"]
+    result = {}
+    for k, v in zip(keys, row):
+        if v is None:
+            continue
+        if k in _int_fields:
+            result[k] = int(v)
+        elif k in _float_fields:
+            result[k] = round(float(v), 6)
+        else:
+            result[k] = v
+    return result
 
 
 def enrich_substance(
@@ -44,6 +76,12 @@ def enrich_substance(
 
     display_name = name or formula
     sources_used = []
+
+    # ── 0. Кристаллографические параметры из reference_structure ─────────
+    properties = _load_crystal_properties(structure_id)
+    if properties:
+        sources_used.append("COD_PARAMS")
+        logger.debug("Crystal properties loaded: {} fields for id={}", len(properties), structure_id)
 
     # ── 1. CrossRef: научные статьи ───────────────────────────────────────
     scientific_sources = []
@@ -87,7 +125,7 @@ def enrich_substance(
         hazards      = ai_result.get("hazards", "")
         sources_used.append("AI")
 
-    if not description and not scientific_sources:
+    if not description and not scientific_sources and not properties:
         logger.warning("substance_enricher: no data found for '{}'", display_name)
         return False
 
@@ -98,7 +136,7 @@ def enrich_substance(
         description=description,
         applications=applications,
         hazards=hazards,
-        properties=None,
+        properties=properties or None,
         scientific_sources=scientific_sources or None,
         enriched_at=datetime.now(),
         enrichment_source="+".join(sources_used),

--- a/cris/db/enrichment/substance_enricher.py
+++ b/cris/db/enrichment/substance_enricher.py
@@ -4,27 +4,29 @@
 Пайплайн:
     1. PubChem     → физико-химические свойства (плотность, т°пл, цвет...)
     2. CrossRef    → топ-5 научных статей по формуле + типу решётки
-    3. GigaChat    → связный текст-описание на основе собранных данных
-    4. substance_info → сохраняем всё в БД (upsert)
+    3. OSTI        → публикации DOE (особенно полезно для ядерных материалов)
+    4. GigaChat    → связный текст-описание на основе собранных данных
+    5. substance_info → сохраняем всё в БД (upsert)
 
 Пример использования:
     from cris.db.enrichment.substance_enricher import enrich_substance
-    enrich_substance(structure_id=1, formula="UO2", lattice_type="cubic")
+    enrich_substance(structure_id=1, formula="UO2", name="Uranium dioxide", lattice_type="cubic")
 """
-import json
 from datetime import datetime
 
 from cris.logger import logger
 from cris.db.models import SubstanceInfo
 from cris.db.repository.substance import get_by_structure, upsert
 from cris.db.enrichment.pubchem_api import get_properties
-from cris.db.enrichment.crossref_api import search_articles
+from cris.db.enrichment.crossref_api import search_articles as crossref_search
+from cris.db.enrichment.osti_api import search_articles as osti_search
 from cris.db.enrichment import gigachat_search
 
 
 def enrich_substance(
     structure_id: int,
     formula: str,
+    name: str = "",
     lattice_type: str = "",
     force: bool = False,
 ) -> bool:
@@ -34,16 +36,15 @@ def enrich_substance(
     Args:
         structure_id: ID в таблице reference_structure
         formula:      химическая формула ("UO2", "NaCl", "Fe")
+        name:         полное название вещества ("Uranium dioxide", "Sodium chloride")
         lattice_type: название типа решётки для контекста поиска
         force:        перезаписать, если данные уже есть
-
-    Returns:
-        True если обогащение прошло успешно
     """
     if not force and get_by_structure(structure_id) is not None:
         logger.debug("substance_info already exists for structure_id={}, skipping", structure_id)
         return True
 
+    display_name = name or formula
     sources_used = []
 
     # ── 1. PubChem: физические свойства ──────────────────────────────────
@@ -52,30 +53,44 @@ def enrich_substance(
     if pubchem_data:
         properties = pubchem_data
         sources_used.append("PUBCHEM")
-        logger.debug("PubChem: {} props for {}", len(pubchem_data), formula)
+        logger.debug("PubChem: {} props for '{}'", len(pubchem_data), formula)
 
     # ── 2. CrossRef: научные статьи ───────────────────────────────────────
     scientific_sources = []
-    query = f"{formula} crystal structure"
+
+    crossref_query = f"{display_name} crystal structure"
     if lattice_type:
-        query += f" {lattice_type}"
+        crossref_query += f" {lattice_type}"
 
-    articles = search_articles(query, max_results=5)
-    if articles:
-        scientific_sources = articles
+    crossref_articles = crossref_search(crossref_query, max_results=5)
+    if crossref_articles:
+        scientific_sources.extend(crossref_articles)
         sources_used.append("CROSSREF")
-        logger.debug("CrossRef: {} articles for '{}'", len(articles), query)
+        logger.debug("CrossRef: {} articles for '{}'", len(crossref_articles), crossref_query)
 
-    # ── 3. GigaChat: связный текст ────────────────────────────────────────
+    # ── 3. OSTI: публикации DOE ───────────────────────────────────────────
+    osti_query = f"{display_name} {formula} crystal structure"
+    osti_articles = osti_search(osti_query, max_results=5)
+    if osti_articles:
+        # дедупликация по doi
+        existing_dois = {a["doi"] for a in scientific_sources if a.get("doi")}
+        new_articles = [a for a in osti_articles if a.get("doi") not in existing_dois]
+        if new_articles:
+            scientific_sources.extend(new_articles)
+            sources_used.append("OSTI")
+            logger.debug("OSTI: {} new articles for '{}'", len(new_articles), osti_query)
+
+    # ── 4. GigaChat: связный текст ────────────────────────────────────────
     description = ""
     applications = ""
     hazards = ""
 
     ai_result = gigachat_search.describe_substance(
         formula=formula,
+        name=display_name,
         lattice_type=lattice_type,
         properties=properties,
-        articles=scientific_sources,
+        articles=scientific_sources[:6],  # не больше 6 статей в промпт
     )
     if ai_result:
         description  = ai_result.get("description", "")
@@ -84,10 +99,10 @@ def enrich_substance(
         sources_used.append("AI")
 
     if not description and not properties and not scientific_sources:
-        logger.warning("substance_enricher: no data found for '{}'", formula)
+        logger.warning("substance_enricher: no data found for '{}'", display_name)
         return False
 
-    # ── 4. Сохраняем ─────────────────────────────────────────────────────
+    # ── 5. Сохраняем ─────────────────────────────────────────────────────
     info = SubstanceInfo(
         id=None,
         structure_id=structure_id,
@@ -100,5 +115,5 @@ def enrich_substance(
         enrichment_source="+".join(sources_used),
     )
     upsert(info)
-    logger.info("Substance enriched: '{}' (sources: {})", formula, info.enrichment_source)
+    logger.info("Substance enriched: '{}' (sources: {})", display_name, info.enrichment_source)
     return True

--- a/cris/db/enrichment/substance_enricher.py
+++ b/cris/db/enrichment/substance_enricher.py
@@ -2,11 +2,10 @@
 Оркестратор обогащения вещества после распознавания.
 
 Пайплайн:
-    1. PubChem     → физико-химические свойства (плотность, т°пл, цвет...)
-    2. CrossRef    → топ-5 научных статей по формуле + типу решётки
-    3. OSTI        → публикации DOE (особенно полезно для ядерных материалов)
-    4. GigaChat    → связный текст-описание на основе собранных данных
-    5. substance_info → сохраняем всё в БД (upsert)
+    1. CrossRef    → топ-5 научных статей по формуле + типу решётки
+    2. OSTI        → публикации DOE (особенно полезно для ядерных материалов)
+    3. GigaChat    → связный текст-описание на основе собранных данных
+    4. substance_info → сохраняем всё в БД (upsert)
 
 Пример использования:
     from cris.db.enrichment.substance_enricher import enrich_substance
@@ -17,7 +16,6 @@ from datetime import datetime
 from cris.logger import logger
 from cris.db.models import SubstanceInfo
 from cris.db.repository.substance import get_by_structure, upsert
-from cris.db.enrichment.pubchem_api import get_properties
 from cris.db.enrichment.crossref_api import search_articles as crossref_search
 from cris.db.enrichment.osti_api import search_articles as osti_search
 from cris.db.enrichment import gigachat_search
@@ -47,15 +45,7 @@ def enrich_substance(
     display_name = name or formula
     sources_used = []
 
-    # ── 1. PubChem: физические свойства ──────────────────────────────────
-    properties = {}
-    pubchem_data = get_properties(formula)
-    if pubchem_data:
-        properties = pubchem_data
-        sources_used.append("PUBCHEM")
-        logger.debug("PubChem: {} props for '{}'", len(pubchem_data), formula)
-
-    # ── 2. CrossRef: научные статьи ───────────────────────────────────────
+    # ── 1. CrossRef: научные статьи ───────────────────────────────────────
     scientific_sources = []
 
     crossref_query = f"{display_name} crystal structure"
@@ -89,7 +79,6 @@ def enrich_substance(
         formula=formula,
         name=display_name,
         lattice_type=lattice_type,
-        properties=properties,
         articles=scientific_sources[:6],  # не больше 6 статей в промпт
     )
     if ai_result:
@@ -98,7 +87,7 @@ def enrich_substance(
         hazards      = ai_result.get("hazards", "")
         sources_used.append("AI")
 
-    if not description and not properties and not scientific_sources:
+    if not description and not scientific_sources:
         logger.warning("substance_enricher: no data found for '{}'", display_name)
         return False
 
@@ -109,7 +98,7 @@ def enrich_substance(
         description=description,
         applications=applications,
         hazards=hazards,
-        properties=properties or None,
+        properties=None,
         scientific_sources=scientific_sources or None,
         enriched_at=datetime.now(),
         enrichment_source="+".join(sources_used),

--- a/cris/db/enrichment/substance_enricher.py
+++ b/cris/db/enrichment/substance_enricher.py
@@ -1,0 +1,104 @@
+"""
+Оркестратор обогащения вещества после распознавания.
+
+Пайплайн:
+    1. PubChem     → физико-химические свойства (плотность, т°пл, цвет...)
+    2. CrossRef    → топ-5 научных статей по формуле + типу решётки
+    3. GigaChat    → связный текст-описание на основе собранных данных
+    4. substance_info → сохраняем всё в БД (upsert)
+
+Пример использования:
+    from cris.db.enrichment.substance_enricher import enrich_substance
+    enrich_substance(structure_id=1, formula="UO2", lattice_type="cubic")
+"""
+import json
+from datetime import datetime
+
+from cris.logger import logger
+from cris.db.models import SubstanceInfo
+from cris.db.repository.substance import get_by_structure, upsert
+from cris.db.enrichment.pubchem_api import get_properties
+from cris.db.enrichment.crossref_api import search_articles
+from cris.db.enrichment import gigachat_search
+
+
+def enrich_substance(
+    structure_id: int,
+    formula: str,
+    lattice_type: str = "",
+    force: bool = False,
+) -> bool:
+    """
+    Обогащает substance_info для указанной структуры.
+
+    Args:
+        structure_id: ID в таблице reference_structure
+        formula:      химическая формула ("UO2", "NaCl", "Fe")
+        lattice_type: название типа решётки для контекста поиска
+        force:        перезаписать, если данные уже есть
+
+    Returns:
+        True если обогащение прошло успешно
+    """
+    if not force and get_by_structure(structure_id) is not None:
+        logger.debug("substance_info already exists for structure_id={}, skipping", structure_id)
+        return True
+
+    sources_used = []
+
+    # ── 1. PubChem: физические свойства ──────────────────────────────────
+    properties = {}
+    pubchem_data = get_properties(formula)
+    if pubchem_data:
+        properties = pubchem_data
+        sources_used.append("PUBCHEM")
+        logger.debug("PubChem: {} props for {}", len(pubchem_data), formula)
+
+    # ── 2. CrossRef: научные статьи ───────────────────────────────────────
+    scientific_sources = []
+    query = f"{formula} crystal structure"
+    if lattice_type:
+        query += f" {lattice_type}"
+
+    articles = search_articles(query, max_results=5)
+    if articles:
+        scientific_sources = articles
+        sources_used.append("CROSSREF")
+        logger.debug("CrossRef: {} articles for '{}'", len(articles), query)
+
+    # ── 3. GigaChat: связный текст ────────────────────────────────────────
+    description = ""
+    applications = ""
+    hazards = ""
+
+    ai_result = gigachat_search.describe_substance(
+        formula=formula,
+        lattice_type=lattice_type,
+        properties=properties,
+        articles=scientific_sources,
+    )
+    if ai_result:
+        description  = ai_result.get("description", "")
+        applications = ai_result.get("applications", "")
+        hazards      = ai_result.get("hazards", "")
+        sources_used.append("AI")
+
+    if not description and not properties and not scientific_sources:
+        logger.warning("substance_enricher: no data found for '{}'", formula)
+        return False
+
+    # ── 4. Сохраняем ─────────────────────────────────────────────────────
+    info = SubstanceInfo(
+        id=None,
+        structure_id=structure_id,
+        description=description,
+        applications=applications,
+        hazards=hazards,
+        properties=properties or None,
+        scientific_sources=scientific_sources or None,
+        enriched_at=datetime.now(),
+        enrichment_source="+".join(sources_used),
+    )
+    upsert(info)
+    logger.info("Substance enriched: '{}' (sources: {})", formula, info.enrichment_source)
+    return True

--- a/cris/db/fixes/diagnose.py
+++ b/cris/db/fixes/diagnose.py
@@ -1,0 +1,156 @@
+"""
+Диагностика БД — показывает все известные проблемы без изменений.
+
+Запуск:
+    python -m cris.db.fixes.diagnose
+
+Выводит:
+  1. Все типы решёток с id
+  2. Все reference_structure: id, formula, name, lattice_type, кол-во sites
+  3. Дублирующиеся формулы
+  4. Структуры без координат
+  5. substance_info: что заполнено, что нет
+"""
+import sys
+import psycopg2
+from cris.db.config import db_config
+
+# Принудительно UTF-8 в Windows-терминале
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+OK   = "[OK]"
+WARN = "[!!]"
+MISS = "[--]"
+
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print('=' * 60)
+
+
+def diagnose() -> None:
+    conn = psycopg2.connect(**db_config)
+    cur = conn.cursor()
+
+    # -- 1. Типы решёток -------------------------------------------------------
+    _section("1. Типы решёток (lattice_type)")
+    cur.execute("SELECT id, name_en, name_ru FROM lattice_type ORDER BY id")
+    for row in cur.fetchall():
+        print(f"  id={row[0]:3d}  {row[1]:<20s}  ({row[2]})")
+
+    # -- 2. Все структуры ------------------------------------------------------
+    _section("2. Все структуры (reference_structure)")
+    cur.execute("""
+        SELECT rs.id, rs.formula, rs.name, lt.name_en,
+               rs.cod_id, rs.mp_id,
+               (rs.xyz_path IS NOT NULL AND rs.xyz_path != '') AS has_xyz,
+               (SELECT COUNT(*) FROM substance_info si WHERE si.structure_id = rs.id) AS has_si
+        FROM reference_structure rs
+        JOIN lattice_type lt ON lt.id = rs.lattice_type_id
+        ORDER BY rs.id
+    """)
+    rows = cur.fetchall()
+    print(f"  {'id':>4}  {'formula':<12}  {'lattice':<16}  {'cod_id':<10}  "
+          f"{'mp_id':<14}  {'xyz':>4}  {'subinf':>6}  name")
+    print(f"  {'-'*4}  {'-'*12}  {'-'*16}  {'-'*10}  {'-'*14}  {'-'*4}  {'-'*6}  {'-'*30}")
+    for struct_id, formula, name, lt_name, cod_id, mp_id, has_xyz, has_si in rows:
+        si_mark  = OK   if has_si  else MISS
+        xyz_mark = OK   if has_xyz else WARN
+        cod_str  = str(cod_id) if cod_id else "---"
+        mp_str   = str(mp_id)  if mp_id  else "---"
+        print(f"  {struct_id:>4}  {(formula or ''):12s}  {lt_name:<16s}  {cod_str:<10s}  "
+              f"{mp_str:<14s}  {xyz_mark:>4}  {si_mark:>6}  {name or ''}")
+
+    # -- 3. Дубликаты ----------------------------------------------------------
+    _section("3. Дублирующиеся формулы")
+    cur.execute("""
+        SELECT REPLACE(formula, ' ', '') AS f_norm, COUNT(*) AS cnt,
+               STRING_AGG(id::text, ', ' ORDER BY id) AS ids
+        FROM reference_structure
+        WHERE formula IS NOT NULL
+        GROUP BY REPLACE(formula, ' ', '')
+        HAVING COUNT(*) > 1
+    """)
+    dups = cur.fetchall()
+    if dups:
+        for f_norm, cnt, ids in dups:
+            print(f"  {WARN} formula~'{f_norm}': {cnt} записи, ids = [{ids}]")
+    else:
+        print(f"  {OK} Дубликатов нет")
+
+    # -- 4. Структуры без XYZ-файла -------------------------------------------
+    _section("4. Структуры БЕЗ xyz_path")
+    cur.execute("""
+        SELECT rs.id, rs.formula, rs.name, lt.name_en
+        FROM reference_structure rs
+        JOIN lattice_type lt ON lt.id = rs.lattice_type_id
+        WHERE rs.xyz_path IS NULL OR rs.xyz_path = ''
+        ORDER BY rs.id
+    """)
+    no_xyz = cur.fetchall()
+    if no_xyz:
+        for struct_id, formula, name, lt_name in no_xyz:
+            print(f"  {WARN} id={struct_id:>3d}  {(formula or ''):12s}  {lt_name:<16s}  {name or ''}")
+        print(f"\n  Итого без xyz_path: {len(no_xyz)}")
+    else:
+        print(f"  {OK} Все структуры имеют xyz_path")
+
+    # -- 5. Потенциально неверные типы решёток --------------------------------
+    _section("5. Потенциальные ошибки типа решётки")
+    cur.execute("""
+        SELECT rs.id, rs.formula, rs.name, lt.name_en
+        FROM reference_structure rs
+        JOIN lattice_type lt ON lt.id = rs.lattice_type_id
+        WHERE rs.formula IN ('Fe', 'W', 'Al', 'Cu')
+          AND lt.name_en != 'cubic'
+    """)
+    wrong = cur.fetchall()
+    if wrong:
+        for struct_id, formula, name, lt_name in wrong:
+            print(f"  {WARN} id={struct_id}  {formula}  '{name}'  -> {lt_name}  (ожидается cubic)")
+    else:
+        print(f"  {OK} Явных ошибок не обнаружено")
+
+    # -- 6. substance_info ----------------------------------------------------
+    _section("6. substance_info: полнота данных")
+    cur.execute("""
+        SELECT si.structure_id, rs.formula, rs.name,
+               (si.description IS NOT NULL AND si.description != '') AS has_desc,
+               (si.applications IS NOT NULL AND si.applications != '') AS has_app,
+               (si.hazards IS NOT NULL AND si.hazards != '') AS has_haz,
+               si.properties IS NOT NULL AS has_props,
+               si.scientific_sources IS NOT NULL AS has_sources,
+               si.enrichment_source
+        FROM substance_info si
+        JOIN reference_structure rs ON rs.id = si.structure_id
+        ORDER BY si.structure_id
+    """)
+    si_rows = cur.fetchall()
+    if si_rows:
+        print(f"  {'id':>4}  {'formula':<12}  {'desc':>4}  {'app':>3}  {'haz':>3}  "
+              f"{'props':>5}  {'srcs':>4}  source")
+        for sid, formula, name, d, a, h, p, s, src in si_rows:
+            def mark(v): return OK if v else MISS
+            print(f"  {sid:>4}  {(formula or ''):12s}  "
+                  f"{mark(d):>4}  {mark(a):>3}  {mark(h):>3}  "
+                  f"{mark(p):>5}  {mark(s):>4}  {src or '---'}")
+    else:
+        print("  substance_info пуст")
+
+    cur.execute("""
+        SELECT COUNT(*) FROM reference_structure rs
+        WHERE NOT EXISTS (SELECT 1 FROM substance_info si WHERE si.structure_id = rs.id)
+    """)
+    missing_si = cur.fetchone()[0]
+    if missing_si:
+        print(f"\n  {WARN} {missing_si} структур без substance_info")
+
+    cur.close()
+    conn.close()
+    print("\n" + "=" * 60)
+
+
+if __name__ == "__main__":
+    diagnose()

--- a/cris/db/fixes/fix_duplicates.py
+++ b/cris/db/fixes/fix_duplicates.py
@@ -1,0 +1,123 @@
+"""
+Баг 1: удаляет дублирующиеся синтетические структуры.
+
+Ситуация:
+  - NaCl:  id=3  (synthetic, formula="NaCl",  без xyz_path)
+           id=22 (COD,       formula="Cl Na", с xyz_path, cod_id=1000041)
+  - MgO:   id=19 (synthetic, formula="MgO",   без xyz_path)
+           id=25 (COD,       formula="Mg O",  с xyz_path, cod_id=1000053)
+
+Стратегия:
+  1. Перевешиваем recognition_result.predicted_structure_id: loser → winner
+  2. Перевешиваем substance_info: если у winner уже есть — просто дадим CASCADE удалить
+     лузерскую; если нет — UPDATE structure_id с loser на winner
+  3. Удаляем reference_structure loser (CASCADE убирает substance_info)
+
+ВАЖНО: recognition_result имеет ON DELETE SET NULL, поэтому перевешиваем ДО удаления.
+
+Запуск:
+    python -m cris.db.fixes.fix_duplicates            # реальное исполнение
+    python -m cris.db.fixes.fix_duplicates --dry-run  # только показать план
+"""
+import sys
+import psycopg2
+from cris.db.config import db_config
+from cris.logger import logger
+
+# (loser_id, winner_id)
+# loser  — синтетическая запись без координат (удаляем)
+# winner — COD-запись с реальными координатами (оставляем)
+PAIRS = [
+    (3,  22),   # NaCl synthetic → NaCl COD (Cl Na, cod_id=1000041)
+    (19, 25),   # MgO  synthetic → MgO  COD (Mg O,  cod_id=1000053)
+]
+
+
+def _describe(cur, struct_id: int) -> str:
+    cur.execute("""
+        SELECT rs.formula, rs.name, rs.cod_id,
+               (rs.xyz_path IS NOT NULL AND rs.xyz_path != '') AS has_xyz
+        FROM reference_structure rs WHERE rs.id = %s
+    """, (struct_id,))
+    row = cur.fetchone()
+    if not row:
+        return f"id={struct_id} [NOT FOUND]"
+    formula, name, cod_id, has_xyz = row
+    return (f"id={struct_id} formula='{formula}' name='{name}' "
+            f"cod_id={cod_id} has_xyz={has_xyz}")
+
+
+def fix_duplicates(dry_run: bool = False) -> None:
+    conn = psycopg2.connect(**db_config)
+    cur = conn.cursor()
+    try:
+        for loser_id, winner_id in PAIRS:
+            loser_desc  = _describe(cur, loser_id)
+            winner_desc = _describe(cur, winner_id)
+
+            # Проверяем что оба существуют
+            cur.execute("SELECT id FROM reference_structure WHERE id = %s", (loser_id,))
+            if not cur.fetchone():
+                logger.info("SKIP pair ({}, {}): loser id={} already gone",
+                            loser_id, winner_id, loser_id)
+                continue
+
+            cur.execute("SELECT id FROM reference_structure WHERE id = %s", (winner_id,))
+            if not cur.fetchone():
+                logger.warning("SKIP pair ({}, {}): winner id={} not found — check PAIRS",
+                               loser_id, winner_id, winner_id)
+                continue
+
+            logger.info("DUPLICATE pair:")
+            logger.info("  KEEP   {}", winner_desc)
+            logger.info("  DELETE {}", loser_desc)
+
+            if dry_run:
+                continue
+
+            # -- a. Перевешиваем recognition_result --------------------------
+            cur.execute("""
+                UPDATE recognition_result
+                SET predicted_structure_id = %s
+                WHERE predicted_structure_id = %s
+            """, (winner_id, loser_id))
+            if cur.rowcount:
+                logger.info("  Moved {} recognition_result rows -> winner", cur.rowcount)
+
+            # -- b. Перевешиваем substance_info ------------------------------
+            cur.execute("SELECT id FROM substance_info WHERE structure_id = %s", (winner_id,))
+            winner_has_si = cur.fetchone() is not None
+
+            cur.execute("SELECT id FROM substance_info WHERE structure_id = %s", (loser_id,))
+            loser_has_si = cur.fetchone() is not None
+
+            if loser_has_si and not winner_has_si:
+                cur.execute("""
+                    UPDATE substance_info SET structure_id = %s WHERE structure_id = %s
+                """, (winner_id, loser_id))
+                logger.info("  Moved substance_info from loser -> winner")
+            elif loser_has_si and winner_has_si:
+                logger.info("  Both have substance_info — loser's will be cascade-deleted")
+
+            # -- c. Удаляем loser (CASCADE: substance_info) ------------------
+            cur.execute("DELETE FROM reference_structure WHERE id = %s", (loser_id,))
+            logger.info("  Deleted reference_structure id={}", loser_id)
+
+        if not dry_run:
+            conn.commit()
+            logger.info("fix_duplicates: done")
+        else:
+            logger.info("[DRY RUN] No changes made")
+
+    except Exception as e:
+        conn.rollback()
+        logger.error("fix_duplicates failed: {}", e)
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    dry = "--dry-run" in sys.argv
+    fix_duplicates(dry_run=dry)

--- a/cris/db/fixes/fix_lattice_types.py
+++ b/cris/db/fixes/fix_lattice_types.py
@@ -1,0 +1,95 @@
+"""
+Баг 2: исправляет неверные типы решёток для Fe и W.
+
+Причина бага: при ручном добавлении синтетических структур lattice_type_id
+был взят неверно (попал monoclinic вместо cubic).
+
+Что делает скрипт:
+  1. Находит id для lattice_type WHERE name_en = 'cubic'
+  2. Для каждой формулы из WRONG_LATTICE_FORMULAS — если текущий тип НЕ cubic,
+     обновляет lattice_type_id → cubic_id
+  3. Выводит что изменилось, а что уже было правильным
+
+Запуск:
+    python -m cris.db.fixes.fix_lattice_types
+"""
+import psycopg2
+from cris.db.config import db_config
+from cris.logger import logger
+
+# Формулы, у которых гарантированно должна быть кубическая решётка (BCC/FCC/SC)
+CUBIC_FORMULAS = {
+    "Fe",   # α-железо — BCC, SG 229 (Im-3m)
+    "W",    # вольфрам  — BCC, SG 229 (Im-3m)
+    "Al",   # алюминий  — FCC, SG 225 (Fm-3m)
+    "Cu",   # медь      — FCC, SG 225 (Fm-3m)
+}
+
+
+def fix_lattice_types(dry_run: bool = False) -> None:
+    conn = psycopg2.connect(**db_config)
+    cur = conn.cursor()
+    try:
+        # ── 1. Находим id кубической решётки ─────────────────────────────
+        cur.execute("SELECT id FROM lattice_type WHERE name_en = 'cubic' LIMIT 1")
+        row = cur.fetchone()
+        if not row:
+            logger.error("lattice_type 'cubic' not found in DB — run lattice_types_init first")
+            return
+        cubic_id = row[0]
+        logger.info("cubic lattice_type id = {}", cubic_id)
+
+        # ── 2. Смотрим что реально лежит в БД ───────────────────────────
+        cur.execute("""
+            SELECT rs.id, rs.formula, rs.name, rs.lattice_type_id, lt.name_en
+            FROM reference_structure rs
+            JOIN lattice_type lt ON lt.id = rs.lattice_type_id
+            WHERE rs.formula = ANY(%s)
+            ORDER BY rs.formula, rs.id
+        """, (list(CUBIC_FORMULAS),))
+        rows = cur.fetchall()
+
+        if not rows:
+            logger.info("No structures with formulas {} found in DB", CUBIC_FORMULAS)
+            return
+
+        fixed = []
+        already_ok = []
+
+        for struct_id, formula, name, lt_id, lt_name in rows:
+            if lt_id == cubic_id:
+                already_ok.append((struct_id, formula, name))
+                logger.info("  OK — id={} '{}' ({}) already cubic", struct_id, name, formula)
+            else:
+                fixed.append((struct_id, formula, name, lt_name))
+                logger.info(
+                    "  FIX — id={} '{}' ({}) : {} → cubic",
+                    struct_id, name, formula, lt_name
+                )
+                if not dry_run:
+                    cur.execute(
+                        "UPDATE reference_structure SET lattice_type_id = %s WHERE id = %s",
+                        (cubic_id, struct_id)
+                    )
+
+        # ── 3. Итог ──────────────────────────────────────────────────────
+        if dry_run:
+            logger.info("[DRY RUN] Would fix {} record(s), {} already OK",
+                        len(fixed), len(already_ok))
+        else:
+            conn.commit()
+            logger.info("Done: fixed={}, already_ok={}", len(fixed), len(already_ok))
+
+    except Exception as e:
+        conn.rollback()
+        logger.error("fix_lattice_types failed: {}", e)
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+    dry = "--dry-run" in sys.argv
+    fix_lattice_types(dry_run=dry)

--- a/cris/db/fixes/load_missing_coords.py
+++ b/cris/db/fixes/load_missing_coords.py
@@ -1,0 +1,211 @@
+"""
+Утилита: заполняет поле xyz_path в reference_structure для структур, у которых оно пустое.
+
+Что делает скрипт:
+  1. Находит все reference_structure, у которых xyz_path IS NULL или пустой
+  2. Для каждой такой структуры ищет подходящий XYZ-файл по формуле или имени
+  3. Обновляет xyz_path в reference_structure
+
+Маппинг XYZ-файлов задан в FORMULA_TO_XYZ (приоритет по формуле).
+Если формула не совпала — пробуем по имени через NAME_KEYWORDS_TO_XYZ.
+
+ВАЖНО: скрипт использует 5x5x5 суперъячейки из data/structures/macro/source/.
+
+Запуск:
+    python -m cris.db.fixes.load_missing_coords            # обновить всё
+    python -m cris.db.fixes.load_missing_coords --dry-run  # только показать план
+    python -m cris.db.fixes.load_missing_coords --id=5     # только одну структуру
+"""
+import sys
+from pathlib import Path
+
+import psycopg2
+
+from cris.db.config import db_config
+from cris.logger import logger
+
+# ── Пути ─────────────────────────────────────────────────────────────────────
+_ROOT = Path(__file__).parent.parent.parent.parent  # корень проекта
+_MACRO_DIR = _ROOT / "data" / "structures" / "macro" / "source"
+
+# ── Маппинг: нормализованная формула → XYZ-файл ──────────────────────────────
+# Ключ: formula.replace(" ", "").upper()
+FORMULA_TO_XYZ: dict[str, str | None] = {
+    # Элементы
+    "AL":    "Al.xyz",          # FCC
+    "BI":    "trig_r_Bi.xyz",   # Rhombohedral
+    "CU":    "Cu.xyz",          # FCC
+    "FE":    "Fe.xyz",          # BCC
+    "IN":    "tetra_i_In.xyz",  # Tetragonal I
+    "NI":    "Cu.xyz",          # FCC — та же нормализованная структура что и Cu
+    "S":     "ortho_f_S.xyz",   # Orthorhombic F
+    "SE":    "mono_p_Se.xyz",   # Monoclinic P
+    "SN":    "tetra_p_Sn.xyz",  # Tetragonal P
+    "TI":    "hex_p_Ti.xyz",    # Hexagonal P
+    "U":     "ortho_p_U.xyz",   # Orthorhombic P (alpha-U)
+    "W":     "Fe.xyz",          # BCC — та же структура что и Fe
+    "ZN":    "hex_p_Zn.xyz",    # Hexagonal P
+    # Бинарные соединения
+    "CSCL":  "CsCl.xyz",        # Cubic SC (2-atom basis)
+    "CLCS":  "CsCl.xyz",
+    "NACL":  "NaCl.xyz",        # Cubic FCC (2-atom basis)
+    "CLNA":  "NaCl.xyz",
+    "UC":    "UC.xyz",          # NaCl-type cubic
+    "UN":    "UN.xyz",          # NaCl-type cubic
+    # Структуры без подходящего XYZ — явно None (пропускаем)
+    "UO2":   None,   # Fluorite cubic — нет XYZ с правильной структурой
+    "PUO2":  None,   # Fluorite cubic
+    "THO2":  None,   # Fluorite cubic
+    "MGO":   None,   # Покрыт COD id=25
+    "SI":    None,   # Diamond cubic — особая структура
+    "GE":    None,   # Diamond cubic
+    "GAAS":  None,   # Zincblende — нет XYZ
+    "ZNS":   None,   # Zincblende — hex_p_Zn.xyz неверен (другая структура)
+    "AL2O3": None,   # Trigonal corundum — нет XYZ
+    "ZRO2":  None,   # Orthorhombic — нет подходящего XYZ
+}
+
+# Дополнительный маппинг по ключевым словам из name.
+# ВАЖНО: более специфичные ключи должны стоять РАНЬШЕ общих.
+NAME_KEYWORDS_TO_XYZ: list[tuple[str, str]] = [
+    # Конкретные соединения — первыми, чтобы не перебивались общими
+    ("sodium chloride",   "NaCl.xyz"),
+    ("caesium chloride",  "CsCl.xyz"),
+    ("cesium chloride",   "CsCl.xyz"),
+    ("uranium carbide",   "UC.xyz"),
+    ("uranium nitride",   "UN.xyz"),
+    # Чистые элементы
+    ("iron",              "Fe.xyz"),
+    ("tungsten",          "Fe.xyz"),   # BCC, как Fe
+    ("aluminium",         "Al.xyz"),
+    ("aluminum",          "Al.xyz"),
+    ("copper",            "Cu.xyz"),
+    ("nickel",            "Cu.xyz"),   # FCC, как Cu
+    ("titanium",          "hex_p_Ti.xyz"),
+    ("zinc metal",        "hex_p_Zn.xyz"),   # только чистый цинк, не соединения
+    ("selenium",          "mono_p_Se.xyz"),
+    ("sulfur",            "ortho_f_S.xyz"),
+    ("sulphur",           "ortho_f_S.xyz"),
+    ("indium",            "tetra_i_In.xyz"),
+    ("tin",               "tetra_p_Sn.xyz"),
+    ("bismuth",           "trig_r_Bi.xyz"),
+]
+
+
+def _find_xyz(formula: str, name: str) -> Path | None:
+    """Ищет XYZ-файл по формуле, затем по имени."""
+    norm_formula = formula.replace(" ", "").upper() if formula else ""
+
+    # 1. Прямое совпадение по формуле
+    if norm_formula in FORMULA_TO_XYZ:
+        filename = FORMULA_TO_XYZ[norm_formula]
+        if filename is None:
+            return None   # явно помечен как «нет XYZ»
+        path = _MACRO_DIR / filename
+        if path.exists():
+            return path
+        logger.warning("  XYZ file mapped but not found: {}", path)
+
+    # 2. Поиск по ключевым словам в имени
+    name_lower = (name or "").lower()
+    for keyword, filename in NAME_KEYWORDS_TO_XYZ:
+        if keyword in name_lower:
+            path = _MACRO_DIR / filename
+            if path.exists():
+                return path
+
+    return None
+
+
+def load_missing_coords(dry_run: bool = False, only_id: int | None = None) -> None:
+    conn = psycopg2.connect(**db_config)
+    cur = conn.cursor()
+    try:
+        # ── 1. Находим структуры без xyz_path ───────────────────────────
+        if only_id:
+            cur.execute("""
+                SELECT rs.id, rs.formula, rs.name, rs.lattice_type_id
+                FROM reference_structure rs
+                WHERE rs.id = %s
+                  AND (rs.xyz_path IS NULL OR rs.xyz_path = '')
+            """, (only_id,))
+        else:
+            cur.execute("""
+                SELECT rs.id, rs.formula, rs.name, rs.lattice_type_id
+                FROM reference_structure rs
+                WHERE rs.xyz_path IS NULL OR rs.xyz_path = ''
+                ORDER BY rs.id
+            """)
+        missing = cur.fetchall()
+
+        if not missing:
+            logger.info("No structures without xyz_path found{}",
+                        f" (id={only_id})" if only_id else "")
+            return
+
+        logger.info("Found {} structure(s) without xyz_path:", len(missing))
+
+        loaded = []
+        skipped = []
+
+        for struct_id, formula, name, lt_id in missing:
+            xyz_path = _find_xyz(formula or "", name or "")
+
+            if xyz_path is None:
+                skipped.append((struct_id, formula, name))
+                logger.warning(
+                    "  SKIP id={} '{}' formula='{}' — no XYZ file found",
+                    struct_id, name, formula
+                )
+                continue
+
+            logger.info(
+                "  LOAD id={} '{}' (formula='{}') ← {}",
+                struct_id, name, formula, xyz_path.name
+            )
+
+            if dry_run:
+                loaded.append((struct_id, formula, name, xyz_path.name))
+                continue
+
+            # ── 2. Обновляем xyz_path в reference_structure ──────────────
+            try:
+                rel_path = str(xyz_path.relative_to(_ROOT)).replace("\\", "/")
+                cur.execute(
+                    "UPDATE reference_structure SET xyz_path = %s WHERE id = %s",
+                    (rel_path, struct_id)
+                )
+                loaded.append((struct_id, formula, name, xyz_path.name))
+                logger.info("    Updated xyz_path={} for structure_id={}", rel_path, struct_id)
+            except Exception as e:
+                logger.error("    Failed for id={}: {}", struct_id, e)
+                skipped.append((struct_id, formula, name))
+
+        # ── 3. Итог ──────────────────────────────────────────────────────
+        if not dry_run:
+            conn.commit()
+
+        status = "[DRY RUN] " if dry_run else ""
+        logger.info(
+            "{}load_missing_coords: loaded={}, skipped={}",
+            status, len(loaded), len(skipped)
+        )
+        if skipped:
+            logger.warning(
+                "Skipped (no XYZ): {}",
+                [(sid, f) for sid, f, _ in skipped]
+            )
+
+    except Exception as e:
+        conn.rollback()
+        logger.error("load_missing_coords failed: {}", e)
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    dry  = "--dry-run" in sys.argv
+    only = next((int(a.split("=")[1]) for a in sys.argv if a.startswith("--id=")), None)
+    load_missing_coords(dry_run=dry, only_id=only)

--- a/cris/db/importers/json_to_db.py
+++ b/cris/db/importers/json_to_db.py
@@ -44,16 +44,27 @@ def insert_data(cursor, data: dict) -> tuple[int, int]:
     row = cursor.fetchone()
     lattice_type_id = row[0] if row else None
 
+    formula = vals.get("_chemical_formula_sum", [""])[0] or vals.get("_chemical_formula_structural", [""])[0]
+    cod_id_raw = vals.get("_cod_database_code", [None])[0]
+    cod_id = int(cod_id_raw) if cod_id_raw else None
+
+    # Проверяем — вдруг уже импортировали (по cod_id или по имени+формуле)
+    if cod_id:
+        cursor.execute("SELECT id FROM reference_structure WHERE cod_id = %s LIMIT 1", (cod_id,))
+        row = cursor.fetchone()
+        if row:
+            return lattice_type_id, row[0]
+
     cursor.execute("""
         INSERT INTO reference_structure
-            (name, lattice_type_id,
+            (name, formula, lattice_type_id,
              cell_length_a, cell_length_b, cell_length_c, cell_volume,
              cell_angle_alpha, cell_angle_beta, cell_angle_gamma,
-             sg_number, sg_hall, sg_hm)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+             sg_number, sg_hall, sg_hm, cod_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id
-    """, (name, lattice_type_id, a, b, c, vol, alpha, beta, gamma,
-          sg_num, sg_hall, sg_hm))
+    """, (name, formula, lattice_type_id, a, b, c, vol, alpha, beta, gamma,
+          sg_num, sg_hall, sg_hm, cod_id))
     structure_id = cursor.fetchone()[0]
 
     labels      = vals.get("_atom_site_label", [])

--- a/cris/db/models.py
+++ b/cris/db/models.py
@@ -20,12 +20,25 @@ class LatticeType:
 @dataclass
 class LatticeMetadata:
     lattice_type_id: int
-    discoverer: str = ""
-    discovery_year: Optional[int] = None
-    discovery_context: str = ""
+    coordination_number: Optional[int] = None   # 12 для FCC, 8 для BCC
+    packing_efficiency: Optional[float] = None  # 0.74 для FCC, 0.68 для BCC
+    typical_materials: str = ""                 # "Al, Cu, Au, Ni"
+    applications: str = ""                      # области применения
     wiki_url: str = ""
-    review_doi: str = ""
     notes: str = ""
+    enriched_at: Optional[datetime] = None
+    enrichment_source: str = ""
+
+
+@dataclass
+class SubstanceInfo:
+    id: Optional[int]
+    structure_id: int
+    description: str = ""          # связный текст от GigaChat
+    applications: str = ""         # применение
+    hazards: str = ""              # токсичность, радиоактивность
+    properties: Optional[dict] = None      # {melting_point, density, color, ...}
+    scientific_sources: Optional[list] = None  # [{doi, title, journal, year, url, snippet}]
     enriched_at: Optional[datetime] = None
     enrichment_source: str = ""
 

--- a/cris/db/queries.py
+++ b/cris/db/queries.py
@@ -1,79 +1,119 @@
 """
 Основная логика поиска эталонных структур по нормализованным координатам.
-Публичный интерфейс не изменился — main.py продолжает работать без правок.
+Координаты читаются напрямую из XYZ-файлов — таблица structure_site не используется.
 """
 from collections import Counter
+from pathlib import Path
+
 from cris.db.connection import get_cursor
+from cris.core.coordinates import shift_coordinates, normalize_coordinates
 from cris.logger import logger
 
+_ROOT = Path(__file__).parent.parent.parent   # корень проекта
+_COORD_TOLERANCE = 1e-4                        # допуск при сравнении координат
 
-_COORD_TOLERANCE = 1e-4  # допуск при сравнении нормализованных координат
+
+# ── Вспомогательные функции ───────────────────────────────────────────────────
+
+def _parse_xyz(xyz_path: Path) -> list[list]:
+    """Парсит XYZ-файл → [[symbol, x, y, z], ...]."""
+    lines = xyz_path.read_text(encoding="utf-8").splitlines()
+    atom_count = int(lines[0].strip())
+    result = []
+    for line in lines[2:2 + atom_count]:
+        parts = line.split()
+        if len(parts) >= 4:
+            result.append([parts[0], float(parts[1]), float(parts[2]), float(parts[3])])
+    return result
 
 
-def get_similar_xyz_from_db(coordinates) -> list:
+def _normalize_xyz(xyz_path: Path) -> list[list] | None:
+    """Загружает XYZ-файл и возвращает нормализованные координаты [[sym, nx, ny, nz], ...]."""
+    try:
+        data = _parse_xyz(xyz_path)
+        shifted = shift_coordinates(data)
+        return normalize_coordinates(shifted)
+    except Exception as e:
+        logger.warning("_normalize_xyz: failed for {}: {}", xyz_path, e)
+        return None
+
+
+# ── Основная функция поиска ───────────────────────────────────────────────────
+
+def check_coords(coordinates: dict, ion_amount: int):
     """
-    Ищет совпадения по нормализованным координатам в structure_site.
-    coordinates: dict {n: [label, x, y, z]}
-    Использует допуск ±_COORD_TOLERANCE вместо точного сравнения float.
-    Возвращает list строк: (site_id, lattice_type_id, structure_id)
+    Ищет эталонные структуры по нормализованным координатам.
+
+    coordinates : dict {n: [label, norm_x, norm_y, norm_z]}  — уже нормализованные
+    ion_amount  : ожидаемое число ионов в эталонной структуре
+
+    Алгоритм:
+      1. Загружаем все reference_structure с xyz_path из БД
+      2. Для каждой структуры читаем XYZ, нормализуем, фильтруем по числу атомов
+      3. Для каждой входной координаты ищем совпадение в эталоне (± tolerance)
+         Каждое совпадение — один голос за эту структуру
+      4. Строим вероятности по числу голосов
+
+    Возвращает [[lattice_names, struct_names], [top_lattice_info, prob], [top_struct_info, prob]]
+    или False если совпадений не найдено.
     """
-    query = """
-        SELECT ss.id, rs.lattice_type_id, ss.structure_id
-        FROM structure_site ss
-        JOIN reference_structure rs ON rs.id = ss.structure_id
-        WHERE ss.norm_x BETWEEN %s AND %s
-          AND ss.norm_y BETWEEN %s AND %s
-          AND ss.norm_z BETWEEN %s AND %s
-    """
-    results = []
+    # 1. Загружаем все структуры с xyz_path
     try:
         with get_cursor() as cur:
-            for _, x, y, z in list(coordinates.values()):
-                x, y, z = float(x), float(y), float(z)  # guard against Decimal from DB
-                cur.execute(query, (
-                    x - _COORD_TOLERANCE, x + _COORD_TOLERANCE,
-                    y - _COORD_TOLERANCE, y + _COORD_TOLERANCE,
-                    z - _COORD_TOLERANCE, z + _COORD_TOLERANCE,
-                ))
-                results.extend(cur.fetchall())
+            cur.execute("""
+                SELECT rs.id, rs.lattice_type_id, rs.xyz_path
+                FROM reference_structure rs
+                WHERE rs.xyz_path IS NOT NULL AND rs.xyz_path != ''
+            """)
+            structures = cur.fetchall()
     except Exception as e:
-        logger.error("get_similar_xyz_from_db failed: {}", e)
-    return results
-
-
-def check_coords(ions: list, ion_amount: int):
-    """
-    Фильтрует совпадения по количеству ионов.
-    Возвращает [[lattice_names, substance_names], [top_lattice, prob], [top_substance, prob]]
-    или False если ничего не найдено.
-    """
-    lattice_list   = [item[1] for item in ions]
-    structure_list = [item[2] for item in ions]
-
-    filtered_lattices   = []
-    filtered_structures = []
-    try:
-        with get_cursor() as cur:
-            for i, struct_id in enumerate(structure_list):
-                cur.execute(
-                    "SELECT COUNT(*) FROM structure_site WHERE structure_id = %s",
-                    (struct_id,)
-                )
-                cnt = cur.fetchone()[0]
-                if cnt == ion_amount:
-                    filtered_lattices.append(lattice_list[i])
-                    filtered_structures.append(struct_id)
-    except Exception as e:
-        logger.error("check_coords (filter by count) failed: {}", e)
-
-    if not filtered_lattices:
+        logger.error("check_coords: failed to load structures from DB: {}", e)
         return False
 
-    lattice_counts = Counter(filtered_lattices)
+    if not structures:
+        logger.warning("check_coords: no reference structures with xyz_path found")
+        return False
+
+    # Нормализованные входные координаты (x, y, z)
+    input_coords = [(float(v[1]), float(v[2]), float(v[3])) for v in coordinates.values()]
+
+    matched_lattices   = []
+    matched_structures = []
+
+    for struct_id, lt_id, xyz_rel_path in structures:
+        xyz_path = _ROOT / xyz_rel_path
+        if not xyz_path.exists():
+            logger.warning("check_coords: XYZ not found for struct_id={}: {}", struct_id, xyz_path)
+            continue
+
+        normalized = _normalize_xyz(xyz_path)
+        if normalized is None:
+            continue
+
+        if len(normalized) != ion_amount:
+            continue
+
+        ref_coords = [(float(r[1]), float(r[2]), float(r[3])) for r in normalized]
+
+        # Для каждой входной координаты считаем один голос, если нашлось совпадение
+        for ix, iy, iz in input_coords:
+            for rx, ry, rz in ref_coords:
+                if (abs(ix - rx) <= _COORD_TOLERANCE and
+                        abs(iy - ry) <= _COORD_TOLERANCE and
+                        abs(iz - rz) <= _COORD_TOLERANCE):
+                    matched_lattices.append(lt_id)
+                    matched_structures.append(struct_id)
+                    break  # один голос за структуру на одну входную координату
+
+    if not matched_lattices:
+        return False
+
+    # 2. Считаем вероятности
+    lattice_counts = Counter(matched_lattices)
     lattice_total  = sum(lattice_counts.values())
     lattice_probs  = {k: v / lattice_total * 100 for k, v in lattice_counts.items()}
 
-    struct_counts  = Counter(filtered_structures)
+    struct_counts  = Counter(matched_structures)
     struct_total   = sum(struct_counts.values())
     struct_probs   = {k: v / struct_total * 100 for k, v in struct_counts.items()}
 
@@ -82,13 +122,15 @@ def check_coords(ions: list, ion_amount: int):
     top_st_id   = max(struct_probs,  key=struct_probs.get)
     top_st_prob = struct_probs[top_st_id]
 
+    # 3. Собираем детальную информацию из БД
     lattice_names  = []
     struct_names   = []
     lattice_info   = None
     structure_info = None
+
     try:
         with get_cursor() as cur:
-            for lt_id in set(filtered_lattices):
+            for lt_id in set(matched_lattices):
                 cur.execute(
                     "SELECT id, name_en, name_ru, description FROM lattice_type WHERE id = %s",
                     (lt_id,)
@@ -99,7 +141,7 @@ def check_coords(ions: list, ion_amount: int):
                     if lt_id == top_lt_id:
                         lattice_info = row
 
-            for st_id in set(filtered_structures):
+            for st_id in set(matched_structures):
                 cur.execute("""
                     SELECT id, name, cell_length_a, cell_length_b, cell_length_c,
                            cell_volume, cell_angle_alpha, cell_angle_beta, cell_angle_gamma,

--- a/cris/db/queries.py
+++ b/cris/db/queries.py
@@ -29,6 +29,7 @@ def get_similar_xyz_from_db(coordinates) -> list:
     try:
         with get_cursor() as cur:
             for _, x, y, z in list(coordinates.values()):
+                x, y, z = float(x), float(y), float(z)  # guard against Decimal from DB
                 cur.execute(query, (
                     x - _COORD_TOLERANCE, x + _COORD_TOLERANCE,
                     y - _COORD_TOLERANCE, y + _COORD_TOLERANCE,

--- a/cris/db/queries.py
+++ b/cris/db/queries.py
@@ -7,23 +7,33 @@ from cris.db.connection import get_cursor
 from cris.logger import logger
 
 
+_COORD_TOLERANCE = 1e-4  # допуск при сравнении нормализованных координат
+
+
 def get_similar_xyz_from_db(coordinates) -> list:
     """
     Ищет совпадения по нормализованным координатам в structure_site.
     coordinates: dict {n: [label, x, y, z]}
-    Возвращает list строк: (site_id, lattice_type_id, structure_id, ...)
+    Использует допуск ±_COORD_TOLERANCE вместо точного сравнения float.
+    Возвращает list строк: (site_id, lattice_type_id, structure_id)
     """
     query = """
         SELECT ss.id, rs.lattice_type_id, ss.structure_id
         FROM structure_site ss
         JOIN reference_structure rs ON rs.id = ss.structure_id
-        WHERE ss.norm_x = %s AND ss.norm_y = %s AND ss.norm_z = %s
+        WHERE ss.norm_x BETWEEN %s AND %s
+          AND ss.norm_y BETWEEN %s AND %s
+          AND ss.norm_z BETWEEN %s AND %s
     """
     results = []
     try:
         with get_cursor() as cur:
             for _, x, y, z in list(coordinates.values()):
-                cur.execute(query, (x, y, z))
+                cur.execute(query, (
+                    x - _COORD_TOLERANCE, x + _COORD_TOLERANCE,
+                    y - _COORD_TOLERANCE, y + _COORD_TOLERANCE,
+                    z - _COORD_TOLERANCE, z + _COORD_TOLERANCE,
+                ))
                 results.extend(cur.fetchall())
     except Exception as e:
         logger.error("get_similar_xyz_from_db failed: {}", e)
@@ -92,7 +102,7 @@ def check_coords(ions: list, ion_amount: int):
                 cur.execute("""
                     SELECT id, name, cell_length_a, cell_length_b, cell_length_c,
                            cell_volume, cell_angle_alpha, cell_angle_beta, cell_angle_gamma,
-                           sg_number, sg_hall, sg_hm, doi
+                           sg_number, sg_hall, sg_hm, doi, formula
                     FROM reference_structure WHERE id = %s
                 """, (st_id,))
                 row = cur.fetchone()

--- a/cris/db/repository/lattice.py
+++ b/cris/db/repository/lattice.py
@@ -41,20 +41,21 @@ def upsert_metadata(meta: LatticeMetadata) -> None:
     with get_cursor() as cur:
         cur.execute("""
             INSERT INTO lattice_metadata
-                (lattice_type_id, discoverer, discovery_year, discovery_context,
-                 wiki_url, review_doi, notes, enriched_at, enrichment_source)
+                (lattice_type_id, coordination_number, packing_efficiency,
+                 typical_materials, applications, wiki_url, notes,
+                 enriched_at, enrichment_source)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (lattice_type_id) DO UPDATE SET
-                discoverer        = EXCLUDED.discoverer,
-                discovery_year    = EXCLUDED.discovery_year,
-                discovery_context = EXCLUDED.discovery_context,
-                wiki_url          = EXCLUDED.wiki_url,
-                review_doi        = EXCLUDED.review_doi,
-                notes             = EXCLUDED.notes,
-                enriched_at       = EXCLUDED.enriched_at,
-                enrichment_source = EXCLUDED.enrichment_source
+                coordination_number = EXCLUDED.coordination_number,
+                packing_efficiency  = EXCLUDED.packing_efficiency,
+                typical_materials   = EXCLUDED.typical_materials,
+                applications        = EXCLUDED.applications,
+                wiki_url            = EXCLUDED.wiki_url,
+                notes               = EXCLUDED.notes,
+                enriched_at         = EXCLUDED.enriched_at,
+                enrichment_source   = EXCLUDED.enrichment_source
         """, (
-            meta.lattice_type_id, meta.discoverer, meta.discovery_year,
-            meta.discovery_context, meta.wiki_url, meta.review_doi,
+            meta.lattice_type_id, meta.coordination_number, meta.packing_efficiency,
+            meta.typical_materials, meta.applications, meta.wiki_url,
             meta.notes, meta.enriched_at or datetime.now(), meta.enrichment_source,
         ))

--- a/cris/db/repository/lattice.py
+++ b/cris/db/repository/lattice.py
@@ -44,15 +44,15 @@ def upsert_metadata(meta: LatticeMetadata) -> None:
                 (lattice_type_id, discoverer, discovery_year, discovery_context,
                  wiki_url, review_doi, notes, enriched_at, enrichment_source)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            ON DUPLICATE KEY UPDATE
-                discoverer        = VALUES(discoverer),
-                discovery_year    = VALUES(discovery_year),
-                discovery_context = VALUES(discovery_context),
-                wiki_url          = VALUES(wiki_url),
-                review_doi        = VALUES(review_doi),
-                notes             = VALUES(notes),
-                enriched_at       = VALUES(enriched_at),
-                enrichment_source = VALUES(enrichment_source)
+            ON CONFLICT (lattice_type_id) DO UPDATE SET
+                discoverer        = EXCLUDED.discoverer,
+                discovery_year    = EXCLUDED.discovery_year,
+                discovery_context = EXCLUDED.discovery_context,
+                wiki_url          = EXCLUDED.wiki_url,
+                review_doi        = EXCLUDED.review_doi,
+                notes             = EXCLUDED.notes,
+                enriched_at       = EXCLUDED.enriched_at,
+                enrichment_source = EXCLUDED.enrichment_source
         """, (
             meta.lattice_type_id, meta.discoverer, meta.discovery_year,
             meta.discovery_context, meta.wiki_url, meta.review_doi,

--- a/cris/db/repository/recognition.py
+++ b/cris/db/repository/recognition.py
@@ -89,12 +89,12 @@ def save_result(session_id: str, method: str, method_version: str,
                  predicted_lattice_type_id, predicted_structure_id,
                  confidence, vector_path)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            ON DUPLICATE KEY UPDATE
-                predicted_lattice_type_id = VALUES(predicted_lattice_type_id),
-                predicted_structure_id    = VALUES(predicted_structure_id),
-                confidence                = VALUES(confidence),
-                vector_path               = VALUES(vector_path),
-                computed_at               = CURRENT_TIMESTAMP
+            ON CONFLICT (session_id, method, method_version, rank) DO UPDATE SET
+                predicted_lattice_type_id = EXCLUDED.predicted_lattice_type_id,
+                predicted_structure_id    = EXCLUDED.predicted_structure_id,
+                confidence                = EXCLUDED.confidence,
+                vector_path               = EXCLUDED.vector_path,
+                computed_at               = NOW()
         """, (session_id, method, method_version, rank,
                lattice_type_id, structure_id, confidence, vector_path or None))
 
@@ -120,7 +120,7 @@ def save_vector_cache(input_hash: str, params: dict, method_name: str,
             INSERT INTO feature_vector_cache
                 (input_hash, params_hash, method_name, vector_path, ion_count)
             VALUES (%s, %s, %s, %s, %s)
-            ON DUPLICATE KEY UPDATE
-                vector_path = VALUES(vector_path),
-                computed_at = CURRENT_TIMESTAMP
+            ON CONFLICT (input_hash, params_hash) DO UPDATE SET
+                vector_path = EXCLUDED.vector_path,
+                computed_at = NOW()
         """, (input_hash, params_hash, method_name, vector_path, ion_count))

--- a/cris/db/repository/structure.py
+++ b/cris/db/repository/structure.py
@@ -1,4 +1,4 @@
-"""CRUD для reference_structure и structure_site."""
+"""CRUD для reference_structure."""
 from typing import Optional
 from cris.db.connection import get_cursor
 from cris.db.models import ReferenceStructure
@@ -53,48 +53,3 @@ def update_external_ids(structure_id: int, *, cod_id: Optional[int] = None,
                 source_url = COALESCE(NULLIF(%s,''), source_url)
             WHERE id = %s
         """, (cod_id, mp_id, doi, source_url, structure_id))
-
-
-def find_matching(normalized_coords: list[tuple[float, float, float]],
-                  ion_count: int) -> list[tuple]:
-    """
-    Ищет эталоны с совпадающими нормализованными координатами
-    и строго нужным количеством ионов.
-    Возвращает строки (lattice_type_id, structure_id, name, name_ru, ...).
-    """
-    if not normalized_coords:
-        return []
-
-    placeholders = " OR ".join(
-        ["(ss.norm_x=%s AND ss.norm_y=%s AND ss.norm_z=%s)"] * len(normalized_coords)
-    )
-    params = [v for xyz in normalized_coords for v in xyz]
-
-    with get_cursor() as cur:
-        cur.execute(f"""
-            SELECT rs.lattice_type_id, ss.structure_id,
-                   rs.name, lt.name_ru, lt.name_en, lt.description,
-                   rs.cell_length_a, rs.cell_length_b, rs.cell_length_c,
-                   rs.cell_volume, rs.cell_angle_alpha, rs.cell_angle_beta, rs.cell_angle_gamma,
-                   rs.sg_number, rs.sg_hall, rs.sg_hm, rs.doi
-            FROM structure_site ss
-            JOIN reference_structure rs ON rs.id = ss.structure_id
-            JOIN lattice_type lt         ON lt.id = rs.lattice_type_id
-            WHERE {placeholders}
-        """, params)
-        hits = cur.fetchall()
-
-    if not hits:
-        return []
-
-    struct_ids = {row[1] for row in hits}
-    fmt = ",".join(["%s"] * len(struct_ids))
-    with get_cursor() as cur:
-        cur.execute(
-            f"SELECT structure_id, COUNT(*) FROM structure_site "
-            f"WHERE structure_id IN ({fmt}) GROUP BY structure_id",
-            list(struct_ids)
-        )
-        counts = {sid: cnt for sid, cnt in cur.fetchall()}
-
-    return [row for row in hits if counts.get(row[1], 0) == ion_count]

--- a/cris/db/repository/substance.py
+++ b/cris/db/repository/substance.py
@@ -1,0 +1,62 @@
+"""CRUD для substance_info — описание вещества после распознавания."""
+import json
+from datetime import datetime
+from typing import Optional
+
+from cris.db.connection import get_cursor
+from cris.db.models import SubstanceInfo
+
+
+def get_by_structure(structure_id: int) -> Optional[SubstanceInfo]:
+    """Возвращает описание вещества по structure_id или None."""
+    with get_cursor() as cur:
+        cur.execute("""
+            SELECT id, structure_id, description, applications, hazards,
+                   properties, scientific_sources, enriched_at, enrichment_source
+            FROM substance_info
+            WHERE structure_id = %s
+        """, (structure_id,))
+        row = cur.fetchone()
+    if not row:
+        return None
+    return SubstanceInfo(
+        id=row[0],
+        structure_id=row[1],
+        description=row[2] or "",
+        applications=row[3] or "",
+        hazards=row[4] or "",
+        properties=row[5],           # psycopg2 вернёт dict из JSONB
+        scientific_sources=row[6],   # psycopg2 вернёт list из JSONB
+        enriched_at=row[7],
+        enrichment_source=row[8] or "",
+    )
+
+
+def upsert(info: SubstanceInfo) -> int:
+    """Сохраняет или обновляет описание вещества. Возвращает id записи."""
+    with get_cursor() as cur:
+        cur.execute("""
+            INSERT INTO substance_info
+                (structure_id, description, applications, hazards,
+                 properties, scientific_sources, enriched_at, enrichment_source)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (structure_id) DO UPDATE SET
+                description        = EXCLUDED.description,
+                applications       = EXCLUDED.applications,
+                hazards            = EXCLUDED.hazards,
+                properties         = EXCLUDED.properties,
+                scientific_sources = EXCLUDED.scientific_sources,
+                enriched_at        = EXCLUDED.enriched_at,
+                enrichment_source  = EXCLUDED.enrichment_source
+            RETURNING id
+        """, (
+            info.structure_id,
+            info.description,
+            info.applications,
+            info.hazards,
+            json.dumps(info.properties, ensure_ascii=False) if info.properties else None,
+            json.dumps(info.scientific_sources, ensure_ascii=False) if info.scientific_sources else None,
+            info.enriched_at or datetime.now(),
+            info.enrichment_source,
+        ))
+        return cur.fetchone()[0]

--- a/cris/db/schema/db_init.sql
+++ b/cris/db/schema/db_init.sql
@@ -141,37 +141,7 @@ CREATE TABLE IF NOT EXISTS substance_info (
 CREATE INDEX IF NOT EXISTS idx_substance_structure ON substance_info (structure_id);
 
 -- ─────────────────────────────────────────────────────────────
--- 6. Позиции ионов в эталонных структурах
--- ─────────────────────────────────────────────────────────────
-CREATE TABLE IF NOT EXISTS structure_site (
-    id           SERIAL PRIMARY KEY,
-    structure_id INT NOT NULL,
-
-    atom_label   VARCHAR(50),   -- e.g. Na1, Cl2
-    atom_symbol  VARCHAR(10),   -- e.g. Na, Cl
-    oxidation    REAL,
-    multiplicity SMALLINT,
-    wyckoff      VARCHAR(10),
-    occupancy    REAL DEFAULT 1.0,
-
-    -- дробные координаты из CIF
-    fract_x      NUMERIC(12, 8),
-    fract_y      NUMERIC(12, 8),
-    fract_z      NUMERIC(12, 8),
-
-    -- нормализованные координаты [0,1]
-    norm_x       NUMERIC(12, 8),
-    norm_y       NUMERIC(12, 8),
-    norm_z       NUMERIC(12, 8),
-
-    FOREIGN KEY (structure_id) REFERENCES reference_structure(id) ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS idx_norm      ON structure_site (norm_x, norm_y, norm_z);
-CREATE INDEX IF NOT EXISTS idx_structure ON structure_site (structure_id);
-
--- ─────────────────────────────────────────────────────────────
--- 7. Сессия распознавания
+-- 6. Сессия распознавания
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS recognition_session (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/cris/db/schema/db_init.sql
+++ b/cris/db/schema/db_init.sql
@@ -14,14 +14,15 @@ END $$;
 
 DO $$ BEGIN
     CREATE TYPE lookup_source_t AS ENUM (
-        'COD', 'MATERIALS_PROJECT', 'ICSD', 'CROSSREF', 'AI_SEARCH', 'MANUAL'
+        'COD', 'MATERIALS_PROJECT', 'ICSD', 'CROSSREF',
+        'PUBCHEM', 'SEMANTIC_SCHOLAR', 'OSTI', 'AI_SEARCH', 'MANUAL'
     );
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
 DO $$ BEGIN
     CREATE TYPE lookup_target_t AS ENUM (
-        'lattice_type', 'reference_structure'
+        'lattice_type', 'reference_structure', 'substance'
     );
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
@@ -53,18 +54,18 @@ CREATE TABLE IF NOT EXISTS lattice_type (
 );
 
 -- ─────────────────────────────────────────────────────────────
--- 2. Метаданные типа решётки (обогащается через внешние API)
+-- 2. Метаданные типа решётки (обогащается через GigaChat)
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS lattice_metadata (
-    lattice_type_id   INT PRIMARY KEY,
-    discoverer        VARCHAR(255),
-    discovery_year    SMALLINT,
-    discovery_context TEXT,
-    wiki_url          VARCHAR(1024),
-    review_doi        VARCHAR(255),
-    notes             TEXT,
-    enriched_at       TIMESTAMP NULL,
-    enrichment_source VARCHAR(50),   -- AI / COD / MP / manual
+    lattice_type_id      INT PRIMARY KEY,
+    coordination_number  SMALLINT,          -- координационное число (12 для FCC, 8 для BCC)
+    packing_efficiency   REAL,              -- плотность упаковки, 0..1 (0.74 для FCC)
+    typical_materials    TEXT,              -- "Al, Cu, Au, Ni, γ-Fe"
+    applications         TEXT,              -- области применения
+    wiki_url             VARCHAR(1024),
+    notes                TEXT,              -- интересные факты
+    enriched_at          TIMESTAMP NULL,
+    enrichment_source    VARCHAR(50),
     FOREIGN KEY (lattice_type_id) REFERENCES lattice_type(id) ON DELETE CASCADE
 );
 
@@ -122,7 +123,25 @@ CREATE TRIGGER trg_rs_updated_at
     FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
 -- ─────────────────────────────────────────────────────────────
--- 4. Позиции ионов в эталонных структурах
+-- 4. Описание вещества (обогащается после распознавания)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS substance_info (
+    id               SERIAL PRIMARY KEY,
+    structure_id     INT NOT NULL UNIQUE,   -- один к одному с reference_structure
+    description      TEXT,                  -- связный текст от GigaChat
+    applications     TEXT,                  -- применение в промышленности/науке
+    hazards          TEXT,                  -- токсичность, радиоактивность и пр.
+    properties       JSONB,                 -- {melting_point, density, color, ...}
+    scientific_sources JSONB,               -- [{doi, title, journal, year, url, snippet}]
+    enriched_at      TIMESTAMP DEFAULT NOW(),
+    enrichment_source VARCHAR(100),         -- "PUBCHEM+CROSSREF+AI"
+    FOREIGN KEY (structure_id) REFERENCES reference_structure(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_substance_structure ON substance_info (structure_id);
+
+-- ─────────────────────────────────────────────────────────────
+-- 6. Позиции ионов в эталонных структурах
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS structure_site (
     id           SERIAL PRIMARY KEY,
@@ -152,7 +171,7 @@ CREATE INDEX IF NOT EXISTS idx_norm      ON structure_site (norm_x, norm_y, norm
 CREATE INDEX IF NOT EXISTS idx_structure ON structure_site (structure_id);
 
 -- ─────────────────────────────────────────────────────────────
--- 5. Сессия распознавания
+-- 7. Сессия распознавания
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS recognition_session (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -166,7 +185,7 @@ CREATE TABLE IF NOT EXISTS recognition_session (
 CREATE INDEX IF NOT EXISTS idx_session_hash ON recognition_session (input_hash);
 
 -- ─────────────────────────────────────────────────────────────
--- 6. Результат распознавания
+-- 8. Результат распознавания
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS recognition_result (
     id              SERIAL PRIMARY KEY,
@@ -186,7 +205,7 @@ CREATE TABLE IF NOT EXISTS recognition_result (
 );
 
 -- ─────────────────────────────────────────────────────────────
--- 7. Кэш feature-векторов (KDE и др.)
+-- 9. Кэш feature-векторов (KDE и др.)
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS feature_vector_cache (
     input_hash   CHAR(64) NOT NULL,   -- SHA-256 нормализованных координат
@@ -199,7 +218,7 @@ CREATE TABLE IF NOT EXISTS feature_vector_cache (
 );
 
 -- ─────────────────────────────────────────────────────────────
--- 8. Лог запросов к внешним источникам
+-- 10. Лог запросов к внешним источникам
 -- ─────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS external_lookup_log (
     id             SERIAL PRIMARY KEY,

--- a/cris/tools/dataset_generation/download_structures.py
+++ b/cris/tools/dataset_generation/download_structures.py
@@ -1,57 +1,80 @@
 """
-Скачивает структуры урановых соединений из Materials Project API
-и сохраняет в data/structures/micro/source/ в формате XYZ.
+Скачивает структуры из Materials Project API, сохраняет XYZ-файлы
+и заносит метаданные в таблицу reference_structure.
 
 API-ключ читается из .env файла (MP_API_KEY=...) или передаётся через --api-key.
 
+Что записывается в reference_structure:
+  name, formula, lattice_type_id (по crystal_system),
+  cell_length_a/b/c, cell_volume, cell_angle_alpha/beta/gamma,
+  sg_number, sg_hm, mp_id, xyz_path, source_url
+
 Использование:
-    python ML/CatBoost/download_structures.py
-    python ML/CatBoost/download_structures.py --limit 50
-    python ML/CatBoost/download_structures.py --formula UC --limit 20
+    python -m cris.tools.dataset_generation.download_structures
+    python -m cris.tools.dataset_generation.download_structures --limit 50
+    python -m cris.tools.dataset_generation.download_structures --formula UC --limit 20
+    python -m cris.tools.dataset_generation.download_structures --dry-run
 
 Зависимости:
-    pip install mp-api python-dotenv
+    pip install mp-api python-dotenv psycopg2-binary
 """
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
+import psycopg2
 from mp_api.client import MPRester
-from pymatgen.io.xyz import XYZ
 
-# Путь для сохранения структур
-OUT_DIR = Path(__file__).parent.parent.parent.parent / "data" / "structures" / "micro" / "source"
+from cris.db.config import db_config
 
-# Элементы для поиска
+# ── Пути ─────────────────────────────────────────────────────────────────────
+_ROOT   = Path(__file__).parent.parent.parent.parent   # корень проекта
+OUT_DIR = _ROOT / "data" / "structures" / "micro" / "source"
+
+# Элементы для поиска (по умолчанию)
 SEARCH_ELEMENTS = ["U"]
 
+# ── Маппинг crystal_system → name_en в таблице lattice_type ──────────────────
+# Materials Project возвращает одно из семи значений crystal_system.
+# Если в БД нет точного совпадения — пробуем ключевые слова из FALLBACK.
+_CRYSTAL_SYSTEM_MAP = {
+    "cubic":        "cubic",
+    "hexagonal":    "hexagonal",
+    "tetragonal":   "tetragonal",
+    "orthorhombic": "orthorhombic",
+    "trigonal":     "trigonal",
+    "monoclinic":   "monoclinic",
+    "triclinic":    "triclinic",
+}
+
+
+# ── Вспомогательные функции ───────────────────────────────────────────────────
 
 def load_api_key(cli_key: str = None) -> str:
     """Читает API-ключ из аргумента CLI, затем из .env, затем из переменной окружения."""
     if cli_key:
         return cli_key
 
-    # Попытка прочитать .env вручную
-    env_path = Path(__file__).parent.parent.parent / ".env"
+    env_path = _ROOT / ".env"
     if env_path.exists():
         for line in env_path.read_text().splitlines():
             line = line.strip()
             if line.startswith("MP_API_KEY=") and not line.startswith("#"):
                 return line.split("=", 1)[1].strip().strip('"').strip("'")
 
-    # Переменная окружения
     key = os.environ.get("MP_API_KEY")
     if key:
         return key
 
     raise ValueError(
-        "API-ключ не найден. Добавьте MP_API_KEY=<ключ> в файл .env "
+        "API-ключ не найден. Добавьте MP_API_KEY=<ключ> в .env "
         "или передайте через --api-key."
     )
 
 
-def structure_to_xyz(structure, filepath: Path, comment: str = ""):
+def structure_to_xyz(structure, filepath: Path, comment: str = "") -> None:
     """Конвертирует pymatgen Structure в XYZ-файл."""
     sites = structure.sites
     lines = [
@@ -60,11 +83,104 @@ def structure_to_xyz(structure, filepath: Path, comment: str = ""):
     ]
     for site in sites:
         coords = site.coords  # Декартовы координаты в Å
-        lines.append(f" {site.specie.symbol}    {coords[0]:.6f}    {coords[1]:.6f}    {coords[2]:.6f}")
-    filepath.write_text("\n".join(lines) + "\n")
+        lines.append(
+            f" {site.specie.symbol}    {coords[0]:.6f}    {coords[1]:.6f}    {coords[2]:.6f}"
+        )
+    filepath.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def download_structures(api_key: str, limit: int = 50, formula: str = None):
+def _get_lattice_type_id(cur, crystal_system: str) -> int | None:
+    """Ищет lattice_type_id по crystal_system из MP API."""
+    name_en = _CRYSTAL_SYSTEM_MAP.get((crystal_system or "").lower())
+    if not name_en:
+        return None
+    cur.execute(
+        "SELECT id FROM lattice_type WHERE LOWER(name_en) = LOWER(%s) LIMIT 1",
+        (name_en,)
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _upsert_structure(cur, *, mp_id: str, name: str, formula: str,
+                      lattice_type_id: int | None,
+                      cell_a: float, cell_b: float, cell_c: float,
+                      cell_vol: float,
+                      angle_alpha: float, angle_beta: float, angle_gamma: float,
+                      sg_number: int | None, sg_hm: str | None,
+                      xyz_path_rel: str,
+                      source_url: str) -> tuple[int, bool]:
+    """
+    Вставляет новую запись или обновляет существующую по mp_id.
+    Возвращает (structure_id, created: bool).
+    """
+    # Проверяем: уже есть такой mp_id?
+    cur.execute("SELECT id FROM reference_structure WHERE mp_id = %s", (mp_id,))
+    existing = cur.fetchone()
+
+    if existing:
+        struct_id = existing[0]
+        cur.execute("""
+            UPDATE reference_structure SET
+                name             = %s,
+                formula          = %s,
+                lattice_type_id  = COALESCE(%s, lattice_type_id),
+                cell_length_a    = %s,
+                cell_length_b    = %s,
+                cell_length_c    = %s,
+                cell_volume      = %s,
+                cell_angle_alpha = %s,
+                cell_angle_beta  = %s,
+                cell_angle_gamma = %s,
+                sg_number        = %s,
+                sg_hm            = %s,
+                xyz_path         = %s,
+                source_url       = %s
+            WHERE id = %s
+        """, (name, formula, lattice_type_id,
+              cell_a, cell_b, cell_c, cell_vol,
+              angle_alpha, angle_beta, angle_gamma,
+              sg_number, sg_hm,
+              xyz_path_rel, source_url,
+              struct_id))
+        return struct_id, False
+    else:
+        # Если lattice_type_id неизвестен — нужен fallback (1 = первая запись)
+        lt_id = lattice_type_id
+        if lt_id is None:
+            cur.execute("SELECT id FROM lattice_type ORDER BY id LIMIT 1")
+            row = cur.fetchone()
+            lt_id = row[0] if row else 1
+
+        cur.execute("""
+            INSERT INTO reference_structure
+                (name, formula, lattice_type_id,
+                 cell_length_a, cell_length_b, cell_length_c, cell_volume,
+                 cell_angle_alpha, cell_angle_beta, cell_angle_gamma,
+                 sg_number, sg_hm,
+                 mp_id, xyz_path, source_url,
+                 existence_status)
+            VALUES
+                (%s, %s, %s,
+                 %s, %s, %s, %s,
+                 %s, %s, %s,
+                 %s, %s,
+                 %s, %s, %s,
+                 'experimental')
+            RETURNING id
+        """, (name, formula, lt_id,
+              cell_a, cell_b, cell_c, cell_vol,
+              angle_alpha, angle_beta, angle_gamma,
+              sg_number, sg_hm,
+              mp_id, xyz_path_rel, source_url))
+        struct_id = cur.fetchone()[0]
+        return struct_id, True
+
+
+# ── Основная функция ──────────────────────────────────────────────────────────
+
+def download_structures(api_key: str, limit: int = 50,
+                        formula: str = None, dry_run: bool = False) -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     print(f"Подключение к Materials Project API...")
@@ -74,7 +190,6 @@ def download_structures(api_key: str, limit: int = 50, formula: str = None):
             fields=["material_id", "formula_pretty", "structure", "symmetry"],
             deprecated=False,
         )
-
         if formula:
             search_kwargs["formula"] = formula
         else:
@@ -83,45 +198,128 @@ def download_structures(api_key: str, limit: int = 50, formula: str = None):
         print(f"Поиск структур (лимит: {limit})...")
         docs = mpr.materials.search(**search_kwargs)
 
-    saved = 0
+    saved   = 0
+    updated = 0
     skipped = 0
 
-    for doc in docs:
-        if saved >= limit:
-            break
+    # Открываем одно соединение на весь цикл
+    conn = psycopg2.connect(**db_config) if not dry_run else None
+    cur  = conn.cursor() if conn else None
 
-        mp_id = doc.material_id
-        formula_pretty = doc.formula_pretty
-        structure = doc.structure
+    try:
+        for doc in docs:
+            if saved + updated >= limit:
+                break
 
-        safe_formula = formula_pretty.replace(" ", "")
-        filename = f"{safe_formula}_{mp_id}.xyz"
-        filepath = OUT_DIR / filename
+            mp_id          = str(doc.material_id)
+            formula_pretty = doc.formula_pretty
+            structure      = doc.structure
+            sym            = doc.symmetry
 
-        if filepath.exists():
-            print(f"  Уже есть: {filename}")
-            skipped += 1
-            continue
+            safe_formula = formula_pretty.replace(" ", "")
+            filename     = f"{safe_formula}_{mp_id}.xyz"
+            filepath     = OUT_DIR / filename
+            xyz_path_rel = str(filepath.relative_to(_ROOT)).replace("\\", "/")
+            source_url   = f"https://materialsproject.org/materials/{mp_id}"
 
-        try:
-            spacegroup = doc.symmetry.symbol if doc.symmetry else "unknown"
-            comment = f"{formula_pretty} {mp_id} sg={spacegroup}"
-            structure_to_xyz(structure, filepath, comment)
-            print(f"  Сохранён: {filename}  ({len(structure.sites)} атомов, {spacegroup})")
-            saved += 1
-        except Exception as e:
-            print(f"  Ошибка {mp_id}: {e}")
+            # ── Параметры ячейки ──────────────────────────────────────────
+            lat = structure.lattice
+            cell_a   = float(lat.a)
+            cell_b   = float(lat.b)
+            cell_c   = float(lat.c)
+            cell_vol = float(lat.volume)
+            alpha    = float(lat.alpha)
+            beta     = float(lat.beta)
+            gamma    = float(lat.gamma)
 
-    print(f"\nГотово: сохранено {saved}, пропущено {skipped}.")
-    print(f"Папка: {OUT_DIR}")
+            sg_hm     = sym.symbol  if sym else None
+            sg_number = int(sym.number) if sym and sym.number else None
+            cs        = sym.crystal_system.value if sym and hasattr(sym.crystal_system, "value") \
+                        else (str(sym.crystal_system) if sym else None)
+
+            # ── XYZ-файл ─────────────────────────────────────────────────
+            comment = f"{formula_pretty} {mp_id} sg={sg_hm or 'unknown'}"
+            if filepath.exists():
+                print(f"  XYZ уже есть: {filename}")
+            elif not dry_run:
+                try:
+                    structure_to_xyz(structure, filepath, comment)
+                    print(f"  XYZ сохранён: {filename}  ({len(structure.sites)} атомов, {sg_hm})")
+                except Exception as e:
+                    print(f"  Ошибка записи XYZ {mp_id}: {e}")
+                    skipped += 1
+                    continue
+            else:
+                print(f"  [DRY RUN] XYZ: {filename}  ({len(structure.sites)} атомов)")
+
+            # ── БД ────────────────────────────────────────────────────────
+            if dry_run:
+                lt_name = _CRYSTAL_SYSTEM_MAP.get((cs or "").lower(), "?")
+                print(f"  [DRY RUN] DB: mp_id={mp_id}  formula={formula_pretty}"
+                      f"  lattice={lt_name}  sg={sg_hm}  a={cell_a:.4f}")
+                saved += 1
+                continue
+
+            try:
+                lt_id = _get_lattice_type_id(cur, cs)
+                if lt_id is None:
+                    print(f"  WARN: crystal_system='{cs}' не найден в lattice_type для {mp_id}")
+
+                struct_id, created = _upsert_structure(
+                    cur,
+                    mp_id        = mp_id,
+                    name         = formula_pretty,
+                    formula      = formula_pretty,
+                    lattice_type_id = lt_id,
+                    cell_a       = cell_a,
+                    cell_b       = cell_b,
+                    cell_c       = cell_c,
+                    cell_vol     = cell_vol,
+                    angle_alpha  = alpha,
+                    angle_beta   = beta,
+                    angle_gamma  = gamma,
+                    sg_number    = sg_number,
+                    sg_hm        = sg_hm,
+                    xyz_path_rel = xyz_path_rel,
+                    source_url   = source_url,
+                )
+                conn.commit()
+
+                action = "INSERT" if created else "UPDATE"
+                print(f"  DB {action}: id={struct_id}  {formula_pretty}  ({mp_id})")
+                if created:
+                    saved += 1
+                else:
+                    updated += 1
+
+            except Exception as e:
+                conn.rollback()
+                print(f"  Ошибка БД {mp_id}: {e}")
+                skipped += 1
+
+    finally:
+        if cur:
+            cur.close()
+        if conn:
+            conn.close()
+
+    status = "[DRY RUN] " if dry_run else ""
+    print(f"\n{status}Готово: вставлено={saved}, обновлено={updated}, пропущено={skipped}.")
+    print(f"Папка XYZ: {OUT_DIR}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Скачать структуры из Materials Project")
     parser.add_argument("--api-key", default=None, help="MP API ключ (или MP_API_KEY в .env)")
-    parser.add_argument("--limit", type=int, default=50, help="Максимум структур (по умолчанию 50)")
-    parser.add_argument("--formula", type=str, default=None, help="Фильтр по формуле, например 'UC' или 'UN2'")
+    parser.add_argument("--limit",   type=int, default=50, help="Максимум структур (по умолчанию 50)")
+    parser.add_argument("--formula", type=str, default=None, help="Фильтр по формуле, например 'UC'")
+    parser.add_argument("--dry-run", action="store_true", help="Показать план без записи в БД")
     args = parser.parse_args()
 
     key = load_api_key(args.api_key)
-    download_structures(api_key=key, limit=args.limit, formula=args.formula)
+    download_structures(
+        api_key  = key,
+        limit    = args.limit,
+        formula  = args.formula,
+        dry_run  = args.dry_run,
+    )

--- a/cris/tools/import_db_structures.py
+++ b/cris/tools/import_db_structures.py
@@ -1,0 +1,84 @@
+"""
+Пакетный импорт структур из data/db/ в PostgreSQL.
+
+Для каждого JSON:
+  1. json_to_db  → reference_structure + structure_site (метаданные и символы)
+  2. xyz_to_db   → structure_site (координаты, если есть XYZ с таким же именем)
+
+Запуск:
+    python -m cris.tools.import_db_structures
+"""
+import json
+import sys
+from pathlib import Path
+
+import psycopg2
+
+from cris.db.config import db_config
+from cris.db.importers.json_to_db import insert_data
+from cris.db.importers.xyz_to_db import parse_xyz, upsert_sites
+from cris.core.coordinates import shift_coordinates, normalize_coordinates
+from cris.logger import logger
+
+DATA_DIR = Path(__file__).parent.parent.parent / "data" / "db"
+JSON_DIR = DATA_DIR / "json"
+XYZ_DIR  = DATA_DIR / "xyz"
+
+
+def import_all() -> None:
+    json_files = sorted(JSON_DIR.glob("*.json"))
+    if not json_files:
+        logger.error("No JSON files found in {}", JSON_DIR)
+        sys.exit(1)
+
+    logger.info("Found {} JSON files to import", len(json_files))
+
+    conn = psycopg2.connect(**db_config)
+    cursor = conn.cursor()
+
+    imported = 0
+    skipped  = 0
+    errors   = 0
+
+    for jf in json_files:
+        stem = jf.stem  # e.g. "1000041"
+        try:
+            with open(jf, encoding="utf-8") as f:
+                data = json.load(f)
+
+            lt_id, struct_id = insert_data(cursor, data)
+            conn.commit()
+
+            # Ищем XYZ с таким же именем (точное совпадение или начинается с stem)
+            xyz_candidates = list(XYZ_DIR.glob(f"{stem}.xyz")) + list(XYZ_DIR.glob(f"{stem}_*.xyz"))
+            if xyz_candidates:
+                xyz_path = xyz_candidates[0]
+                raw       = parse_xyz(str(xyz_path))
+                shifted   = shift_coordinates(raw)
+                normalized = normalize_coordinates(shifted)
+                upsert_sites(cursor, raw, normalized, struct_id, lt_id)
+                conn.commit()
+                logger.info("  ✓ {} → structure_id={} lt={} sites={}", stem, struct_id, lt_id, len(raw))
+            else:
+                logger.warning("  ~ {} → structure_id={} (no XYZ found)", stem, struct_id)
+
+            imported += 1
+
+        except Exception as e:
+            conn.rollback()
+            # Если структура уже была — это не ошибка
+            if "already" in str(e).lower() or struct_id:
+                skipped += 1
+                logger.debug("  = {} skipped ({})", stem, str(e)[:60])
+            else:
+                errors += 1
+                logger.error("  ✗ {} failed: {}", stem, e)
+
+    cursor.close()
+    conn.close()
+
+    logger.info("Done: imported={} skipped={} errors={}", imported, skipped, errors)
+
+
+if __name__ == "__main__":
+    import_all()

--- a/docs/db_schema.html
+++ b/docs/db_schema.html
@@ -2,506 +2,578 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8">
-<title>crystal_lattice_db — схема БД</title>
+<title>Схема БД — crystal_lattice_db</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-
   body {
-    background: #0f1117;
     font-family: 'Segoe UI', system-ui, sans-serif;
+    background: #0f1117;
     color: #e2e8f0;
-    min-height: 100vh;
     padding: 32px;
+    line-height: 1.5;
   }
 
-  h1 {
-    text-align: center;
-    font-size: 22px;
-    font-weight: 600;
-    color: #94a3b8;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .subtitle {
-    text-align: center;
-    font-size: 13px;
-    color: #475569;
-    margin-bottom: 40px;
-    letter-spacing: 1px;
-  }
+  h1 { font-size: 1.6rem; font-weight: 700; color: #f8fafc; margin-bottom: 6px; }
+  .subtitle { color: #64748b; font-size: 0.9rem; margin-bottom: 40px; }
 
-  /* ── ЛЕГЕНДА ─────────────────────────────────────── */
   .legend {
-    display: flex;
-    justify-content: center;
-    gap: 24px;
-    margin-bottom: 36px;
-    flex-wrap: wrap;
+    display: flex; gap: 20px; margin-bottom: 36px; flex-wrap: wrap;
   }
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 12px;
-    color: #94a3b8;
-  }
-  .legend-dot {
-    width: 12px; height: 12px;
-    border-radius: 3px;
-  }
+  .legend-item { display: flex; align-items: center; gap: 8px; font-size: 0.82rem; color: #94a3b8; }
+  .dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
 
-  /* ── CANVAS ──────────────────────────────────────── */
-  .canvas {
-    position: relative;
-    width: 1200px;
-    margin: 0 auto;
-    height: 860px;
+  .groups { display: flex; flex-direction: column; gap: 40px; }
+  .group-label {
+    font-size: 0.72rem; font-weight: 700; letter-spacing: .12em;
+    text-transform: uppercase; color: #475569; margin-bottom: 12px;
   }
+  .tables-row { display: flex; gap: 20px; flex-wrap: wrap; align-items: flex-start; }
 
-  svg.lines {
-    position: absolute;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    pointer-events: none;
-    overflow: visible;
-  }
-
-  /* ── ТАБЛИЦА ─────────────────────────────────────── */
   .table {
-    position: absolute;
-    width: 240px;
     border-radius: 10px;
     overflow: hidden;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.5);
-    border: 1px solid rgba(255,255,255,0.06);
-  }
-
-  .table-header {
-    padding: 10px 14px;
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .table-header .icon { font-size: 15px; }
-  .table-header .tname { flex: 1; }
-  .table-header .badge {
-    font-size: 10px;
-    font-weight: 600;
-    padding: 2px 6px;
-    border-radius: 4px;
-    background: rgba(0,0,0,0.25);
-    opacity: 0.8;
-  }
-
-  .table-body {
-    background: #1a1d27;
-  }
-
-  .col {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 5px 14px;
-    font-size: 11.5px;
-    border-bottom: 1px solid rgba(255,255,255,0.04);
-    transition: background 0.15s;
-  }
-  .col:hover { background: rgba(255,255,255,0.04); }
-  .col:last-child { border-bottom: none; }
-
-  .col-icon {
-    width: 14px;
-    text-align: center;
-    font-size: 11px;
-    flex-shrink: 0;
-  }
-  .col-name {
+    min-width: 280px;
+    max-width: 380px;
     flex: 1;
-    color: #cbd5e1;
+    box-shadow: 0 4px 24px rgba(0,0,0,.5);
+    border: 1px solid rgba(255,255,255,.06);
   }
-  .col-name.pk { color: #fbbf24; font-weight: 600; }
-  .col-name.fk { color: #818cf8; }
-  .col-name.important { color: #e2e8f0; font-weight: 500; }
-
-  .col-type {
-    font-size: 10px;
-    color: #475569;
-    font-family: 'Consolas', monospace;
-    flex-shrink: 0;
+  .table-header {
+    padding: 11px 16px;
+    font-weight: 700;
+    font-size: 0.95rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    letter-spacing: .01em;
   }
-
-  .col-divider {
-    height: 1px;
-    background: rgba(255,255,255,0.08);
-    margin: 2px 0;
+  .table-header .badge {
+    font-size: 0.7rem; font-weight: 600;
+    background: rgba(0,0,0,.25); border-radius: 20px;
+    padding: 2px 9px; letter-spacing: .02em;
   }
-
-  /* ── ЦВЕТА ТАБЛИЦ ────────────────────────────────── */
-  /* справочник */
-  .t-ref .table-header    { background: #1e3a5f; }
-  .t-ref .table-header    { border-bottom: 2px solid #3b82f6; }
-  /* структуры */
-  .t-struct .table-header { background: #14532d; border-bottom: 2px solid #22c55e; }
-  /* распознавание */
-  .t-recog .table-header  { background: #3b1f5e; border-bottom: 2px solid #a855f7; }
-  /* кэш */
-  .t-cache .table-header  { background: #1c3a3a; border-bottom: 2px solid #14b8a6; }
-  /* лог */
-  .t-log .table-header    { background: #3b2a14; border-bottom: 2px solid #f59e0b; }
-
-  /* ── СВЯЗИ ───────────────────────────────────────── */
-  .rel-line {
-    stroke-width: 1.5;
-    fill: none;
-    opacity: 0.55;
+  .col-list { background: #1a1d27; }
+  .col {
+    display: grid;
+    grid-template-columns: 20px 1fr auto;
+    gap: 8px;
+    padding: 7px 16px;
+    border-top: 1px solid rgba(255,255,255,.04);
+    align-items: start;
+    font-size: 0.82rem;
   }
-  .rel-fk    { stroke: #818cf8; stroke-dasharray: none; }
-  .rel-set   { stroke: #f59e0b; stroke-dasharray: 5,3; }
+  .col:hover { background: rgba(255,255,255,.03); }
+  .col-icon { font-size: 0.75rem; padding-top: 1px; }
+  .col-name { color: #e2e8f0; font-weight: 500; }
+  .col-name.pk { color: #fbbf24; }
+  .col-name.fk { color: #60a5fa; }
+  .col-name.uk { color: #a78bfa; }
+  .col-meta { color: #475569; font-size: 0.75rem; text-align: right; white-space: nowrap; }
+  .col-desc { grid-column: 2 / -1; color: #64748b; font-size: 0.76rem; padding-top: 1px; }
 
-  .rel-label {
-    font-size: 10px;
-    fill: #64748b;
-    font-family: 'Segoe UI', sans-serif;
+  .th-teal   { background: linear-gradient(135deg,#0f766e,#0d9488); color: #ccfbf1; }
+  .th-blue   { background: linear-gradient(135deg,#1d4ed8,#2563eb); color: #dbeafe; }
+  .th-violet { background: linear-gradient(135deg,#6d28d9,#7c3aed); color: #ede9fe; }
+  .th-amber  { background: linear-gradient(135deg,#b45309,#d97706); color: #fef3c7; }
+  .th-slate  { background: linear-gradient(135deg,#334155,#475569); color: #f1f5f9; }
+
+  .relations {
+    margin-top: 40px; background: #1a1d27;
+    border-radius: 10px; border: 1px solid rgba(255,255,255,.06); overflow: hidden;
   }
+  .relations-header {
+    background: linear-gradient(135deg,#1e293b,#334155);
+    padding: 12px 20px; font-weight: 700; font-size: 0.95rem; color: #f1f5f9;
+  }
+  .rel-table { width: 100%; border-collapse: collapse; }
+  .rel-table th {
+    text-align: left; padding: 8px 16px;
+    font-size: 0.75rem; font-weight: 700; letter-spacing: .08em;
+    text-transform: uppercase; color: #475569;
+    border-bottom: 1px solid rgba(255,255,255,.06);
+  }
+  .rel-table td {
+    padding: 9px 16px; font-size: 0.82rem;
+    border-bottom: 1px solid rgba(255,255,255,.04); vertical-align: top;
+  }
+  .rel-table tr:hover td { background: rgba(255,255,255,.02); }
+  .rel-from { color: #60a5fa; font-weight: 600; }
+  .rel-to   { color: #fbbf24; font-weight: 600; }
+  .rel-type { color: #94a3b8; }
+  .rel-desc { color: #64748b; font-size: 0.78rem; }
+  .on-del-cascade { color: #f87171; font-size: 0.75rem; }
+  .on-del-null    { color: #94a3b8; font-size: 0.75rem; }
 
-  marker path { stroke: none; }
+  .flows {
+    margin-top: 16px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 20px;
+  }
+  .flow-card {
+    background: #1a1d27; border-radius: 10px;
+    border: 1px solid rgba(255,255,255,.06); padding: 18px 20px;
+  }
+  .flow-title { font-weight: 700; font-size: 0.9rem; color: #f1f5f9; margin-bottom: 12px; }
+  .flow-step {
+    display: flex; align-items: flex-start; gap: 10px;
+    font-size: 0.82rem; color: #94a3b8; margin-bottom: 8px;
+  }
+  .flow-num {
+    width: 22px; height: 22px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 0.72rem; font-weight: 700; flex-shrink: 0;
+    background: #1e293b; color: #60a5fa; border: 1px solid #334155;
+  }
+  .flow-text strong { color: #e2e8f0; }
 
-  /* ── СЕКЦИИ (группировка) ────────────────────────── */
-  .section-label {
-    position: absolute;
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    color: #334155;
+  .notes {
+    margin-top: 16px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 16px;
+  }
+  .note {
+    background: #1a1d27; border-radius: 8px;
+    border-left: 3px solid #334155; padding: 14px 16px; font-size: 0.82rem;
+  }
+  .note.warn { border-color: #f59e0b; }
+  .note.ok   { border-color: #10b981; }
+  .note.info { border-color: #3b82f6; }
+  .note-title { font-weight: 700; font-size: 0.85rem; margin-bottom: 6px; }
+  .note.warn .note-title { color: #fbbf24; }
+  .note.ok   .note-title { color: #34d399; }
+  .note.info .note-title { color: #60a5fa; }
+  .note p { color: #64748b; line-height: 1.55; }
+  .note code {
+    background: #0f1117; padding: 1px 5px; border-radius: 3px;
+    color: #a78bfa; font-family: monospace; font-size: 0.8rem;
   }
 </style>
 </head>
 <body>
 
-<h1>crystal_lattice_db</h1>
-<div class="subtitle">PostgreSQL · 8 таблиц · feature/database-redesign</div>
+<h1>Схема базы данных — crystal_lattice_db</h1>
+<p class="subtitle">PostgreSQL &middot; 9 таблиц &middot; ветка feature/database-redesign &middot; обновлено 2026-05-11</p>
 
 <div class="legend">
-  <div class="legend-item"><div class="legend-dot" style="background:#3b82f6"></div> Справочник решёток</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#22c55e"></div> Эталонные структуры</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#a855f7"></div> Распознавание</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#14b8a6"></div> Кэш векторов</div>
-  <div class="legend-item"><div class="legend-dot" style="background:#f59e0b"></div> Лог запросов</div>
+  <div class="legend-item"><div class="dot" style="background:#fbbf24"></div> PK &mdash; первичный ключ</div>
+  <div class="legend-item"><div class="dot" style="background:#60a5fa"></div> FK &mdash; внешний ключ</div>
+  <div class="legend-item"><div class="dot" style="background:#a78bfa"></div> UK &mdash; уникальное ограничение</div>
+  <div class="legend-item"><div class="dot" style="background:#475569"></div> &mdash; обычное поле</div>
+  <div class="legend-item">&#128273; PK &nbsp; &#128279; FK &nbsp; &#128274; UK &nbsp; &middot; обычное</div>
 </div>
 
-<div class="canvas" id="canvas">
+<div class="groups">
 
-<!-- ── SVG СВЯЗИ ──────────────────────────────────────────────────── -->
-<svg class="lines" id="svg">
-  <defs>
-    <marker id="arr-blue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#818cf8"/>
-    </marker>
-    <marker id="arr-amber" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#f59e0b"/>
-    </marker>
-    <marker id="arr-green" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#22c55e"/>
-    </marker>
-    <marker id="arr-purple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#a855f7"/>
-    </marker>
-    <marker id="arr-teal" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L0,6 L8,3 z" fill="#14b8a6"/>
-    </marker>
-  </defs>
-</svg>
+  <!-- GROUP 1 -->
+  <div>
+    <div class="group-label">&#9312; Справочник кристаллических систем</div>
+    <div class="tables-row">
 
-<!-- ═══════════════════════════════════════════════════════════════
-     КОЛОНКА 1 — СПРАВОЧНИК РЕШЁТОК
-═══════════════════════════════════════════════════════════════ -->
+      <div class="table">
+        <div class="table-header th-teal">lattice_type <span class="badge">8 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col-desc">Автоинкремент 1&ndash;8. Каждое значение = одна кристаллическая система</div>
+          <div class="col"><span class="col-icon">&#128274;</span><span class="col-name uk">name_en</span><span class="col-meta">varchar UK</span></div>
+          <div class="col-desc">cubic, hexagonal, trigonal, tetragonal, orthorhombic, monoclinic, rhombohedral, triclinic</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">name_ru</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Русское название: кубическая, гексагональная &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">bravais_lattice</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Символ решётки Браве: cF, cI, cP, hP, mP &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">point_group</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Точечная группа симметрии: m3m, 6/mmm, 4/mmm &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">sg_number_min / max</span><span class="col-meta">smallint</span></div>
+          <div class="col-desc">Диапазон номеров пространственных групп МТК для этой системы (напр. cubic: 195&ndash;230)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">description</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Текстовое описание для отображения в UI (заполнено вручную)</div>
+        </div>
+      </div>
 
-<!-- lattice_type -->
-<div class="table t-ref" id="t-lattice_type" style="left:20px; top:40px;">
-  <div class="table-header">
-    <span class="icon">🔷</span>
-    <span class="tname">lattice_type</span>
-    <span class="badge">справочник</span>
+      <div class="table">
+        <div class="table-header th-teal">lattice_metadata <span class="badge">8 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk pk">lattice_type_id</span><span class="col-meta">int PK/FK/UK</span></div>
+          <div class="col-desc">Ключ 1:1 с lattice_type.id. Одна запись метаданных = один тип решётки</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">coordination_number</span><span class="col-meta">smallint</span></div>
+          <div class="col-desc">Число ближайших соседей у атома: FCC=12, BCC=8, SC=6</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">packing_efficiency</span><span class="col-meta">real</span></div>
+          <div class="col-desc">Доля объёма ячейки, занятая атомами: FCC=0.74, BCC=0.68, SC=0.52</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">typical_materials</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Примеры веществ: "Al, Cu, NaCl, Ag &hellip;"</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">applications</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Практическое применение: металлургия, полупроводники, ядерная энергетика &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">wiki_url / notes</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Ссылка на Wikipedia и дополнительные заметки</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">enrichment_source</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Источник: "AI_SEARCH" &mdash; все поля сгенерированы GigaChat-2-Max</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">enriched_at</span><span class="col-meta">timestamp</span></div>
+        </div>
+      </div>
+
+    </div>
   </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">name_en</span><span class="col-type">VARCHAR UNIQUE</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">name_ru</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">crystal_system</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">bravais_lattice</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">point_group</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number_min</span><span class="col-type">SMALLINT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number_max</span><span class="col-type">SMALLINT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">description</span><span class="col-type">TEXT</span></div>
+
+  <!-- GROUP 2 -->
+  <div>
+    <div class="group-label">&#9313; Эталонные кристаллические структуры</div>
+    <div class="tables-row">
+
+      <div class="table">
+        <div class="table-header th-blue">reference_structure <span class="badge">30 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk">lattice_type_id</span><span class="col-meta">int FK</span></div>
+          <div class="col-desc">К какой кристаллической системе относится &rarr; lattice_type.id (N:1)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">name</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Полное название: "Sodium chloride", "Uranium dioxide" &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">formula</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Химическая формула. COD хранит алфавитно: "Cl Na" вместо "NaCl"</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">cell_length_a / b / c</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Параметры элементарной ячейки в ангстремах (&#8491;)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">cell_volume</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Объём элементарной ячейки в &#8491;&#179;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">cell_angle_alpha / beta / gamma</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Углы между осями в градусах. Для кубической все = 90&deg;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">sg_number</span><span class="col-meta">smallint</span></div>
+          <div class="col-desc">Номер пространственной группы по МТК (1&ndash;230)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">sg_hall / sg_hm</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Обозначения пространственной группы: нотация Холла и Германа&ndash;Могена</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">cod_id</span><span class="col-meta">integer</span></div>
+          <div class="col-desc">ID записи в Crystallography Open Database. NULL у синтетических структур</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">existence_status</span><span class="col-meta">enum</span></div>
+          <div class="col-desc">experimental / theoretical / hypothetical / disputed</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">doi / source_url</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Источник публикации для верификации структуры</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">added_at / updated_at</span><span class="col-meta">timestamp</span></div>
+        </div>
+      </div>
+
+      <div class="table">
+        <div class="table-header th-blue">structure_site <span class="badge">390 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk">structure_id</span><span class="col-meta">int FK</span></div>
+          <div class="col-desc">Атом принадлежит этой структуре &rarr; reference_structure.id (N:1)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">atom_label</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Метка из CIF: "Na1", "Cl1" &hellip; NULL для дублированных позиций из XYZ</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">atom_symbol</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Символ элемента: Na, Cl, U, Fe &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">oxidation</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Степень окисления: +1, &minus;1, +4 &hellip; (из CIF, NULL если не указана)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">multiplicity</span><span class="col-meta">smallint</span></div>
+          <div class="col-desc">Кратность положения Вайкова &mdash; число эквивалентных позиций в ячейке</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">wyckoff</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Буква положения Вайкова: a, b, c, d &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">occupancy</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Заселённость 0&ndash;1. 1.0 = позиция полностью занята атомом</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">fract_x / fract_y / fract_z</span><span class="col-meta">numeric</span></div>
+          <div class="col-desc">Абсолютные координаты из XYZ в &#8491; (название исторически неточное)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">norm_x / norm_y / norm_z</span><span class="col-meta">numeric</span></div>
+          <div class="col-desc">Нормализованные координаты [0,1] &mdash; именно по ним идёт поиск совпадений с допуском &#177;1e-4</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- GROUP 3 -->
+  <div>
+    <div class="group-label">&#9314; Обогащение веществ (AI + научные базы данных)</div>
+    <div class="tables-row">
+
+      <div class="table">
+        <div class="table-header th-violet">substance_info <span class="badge">21 строка</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk uk">structure_id</span><span class="col-meta">int FK/UK</span></div>
+          <div class="col-desc">1:1 с reference_structure.id (UNIQUE). Одна запись обогащения на вещество</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">description</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Связное описание вещества, написанное GigaChat на основе статей</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">applications</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Области применения: ядерная энергетика, электроника, металлургия &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">hazards</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Опасности: радиоактивность, токсичность. Пустая строка если нет</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">properties</span><span class="col-meta">jsonb</span></div>
+          <div class="col-desc">Кристаллографические параметры из reference_structure в виде JSON-объекта: cell_length_a/b/c, cell_volume, angles, sg_number, sg_hall, sg_hm, cod_id</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">scientific_sources</span><span class="col-meta">jsonb</span></div>
+          <div class="col-desc">JSON-массив статей [{doi, title, journal, year, url, source}]. До 10 статей. Источники: CrossRef + OSTI DOE</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">enrichment_source</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Строка-перечень: "COD_PARAMS+CROSSREF+OSTI+AI"</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">enriched_at</span><span class="col-meta">timestamp</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- GROUP 4 -->
+  <div>
+    <div class="group-label">&#9315; История распознаваний</div>
+    <div class="tables-row">
+
+      <div class="table">
+        <div class="table-header th-amber">recognition_session <span class="badge">1 строка</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">uuid PK</span></div>
+          <div class="col-desc">UUID, генерируется автоматически при каждом новом наборе координат</div>
+          <div class="col"><span class="col-icon">&#128274;</span><span class="col-name uk">input_hash</span><span class="col-meta">char(64) UK</span></div>
+          <div class="col-desc">SHA-256 от нормализованных координат. Если тот же хэш &mdash; сессия переиспользуется (кэш)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">ion_count</span><span class="col-meta">integer</span></div>
+          <div class="col-desc">Количество ионов, введённых пользователем</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">xyz_path</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Путь к XYZ-файлу если ввод из файла. Пустая строка если ввод через UI</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">notes / created_at</span><span class="col-meta">text / timestamp</span></div>
+        </div>
+      </div>
+
+      <div class="table">
+        <div class="table-header th-amber">recognition_result <span class="badge">4 строки</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk">session_id</span><span class="col-meta">uuid FK</span></div>
+          <div class="col-desc">К какой сессии относится &rarr; recognition_session.id (N:1)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">method</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Алгоритм: "COORD_MATCH" (поиск по БД) или "CATBOOST" (ML-модель)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">method_version</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Версия: "1.0". Позволяет сравнивать разные версии одного алгоритма</div>
+          <div class="col"><span class="col-icon">&#128274;</span><span class="col-name uk">rank</span><span class="col-meta">smallint UK*</span></div>
+          <div class="col-desc">Место в топе: 1=лучший, 2=второй &hellip; UK по (session_id, method, version, rank)</div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk">predicted_lattice_type_id</span><span class="col-meta">int FK</span></div>
+          <div class="col-desc">Предсказанный тип решётки &rarr; lattice_type.id. ON DELETE SET NULL</div>
+          <div class="col"><span class="col-icon">&#128279;</span><span class="col-name fk">predicted_structure_id</span><span class="col-meta">int FK</span></div>
+          <div class="col-desc">Конкретная структура (NULL для CATBOOST) &rarr; reference_structure.id. ON DELETE SET NULL</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">confidence</span><span class="col-meta">float8</span></div>
+          <div class="col-desc">Уверенность 0.0&ndash;1.0. COORD_MATCH: доля голосов; CATBOOST: вероятность класса</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">vector_path / computed_at</span><span class="col-meta">varchar / ts</span></div>
+          <div class="col-desc">Путь к KDE-вектору на диске (для воспроизводимости) и время расчёта</div>
+        </div>
+      </div>
+
+      <div class="table">
+        <div class="table-header th-amber">feature_vector_cache <span class="badge">0 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128274;</span><span class="col-name uk">input_hash</span><span class="col-meta">char(64) UK*</span></div>
+          <div class="col-desc">SHA-256 от координат &mdash; связывает с recognition_session.input_hash</div>
+          <div class="col"><span class="col-icon">&#128274;</span><span class="col-name uk">params_hash</span><span class="col-meta">char(64) UK*</span></div>
+          <div class="col-desc">SHA-256 от параметров модели (bandwidth, grid size &hellip;). UK по паре (input_hash, params_hash)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">method_name</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Метод, считавший вектор: "KDE_RF", "CATBOOST" &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">vector_path</span><span class="col-meta">varchar</span></div>
+          <div class="col-desc">Путь к .npy файлу на диске с numpy-массивом вектора</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">ion_count / computed_at</span><span class="col-meta">int / ts</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- GROUP 5 -->
+  <div>
+    <div class="group-label">&#9316; Логирование внешних запросов</div>
+    <div class="tables-row">
+
+      <div class="table">
+        <div class="table-header th-slate">external_lookup_log <span class="badge">26 строк</span></div>
+        <div class="col-list">
+          <div class="col"><span class="col-icon">&#128273;</span><span class="col-name pk">id</span><span class="col-meta">integer PK</span></div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">source</span><span class="col-meta">enum</span></div>
+          <div class="col-desc">COD / MATERIALS_PROJECT / CROSSREF / PUBCHEM / OSTI / AI_SEARCH / MANUAL</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">target_type</span><span class="col-meta">enum</span></div>
+          <div class="col-desc">Что обогащали: lattice_type / structure / substance</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">target_id</span><span class="col-meta">integer</span></div>
+          <div class="col-desc">ID объекта в соответствующей таблице. Не FK, т.к. target_type разный</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">query_text</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Точный текст запроса к внешнему API</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">result_summary</span><span class="col-meta">text</span></div>
+          <div class="col-desc">Краткое содержание ответа (первые N символов)</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">enriched_fields</span><span class="col-meta">jsonb</span></div>
+          <div class="col-desc">Список заполненных полей: ["description", "applications", "hazards"]</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">http_status</span><span class="col-meta">smallint</span></div>
+          <div class="col-desc">HTTP-статус: 200, 404, 500 &hellip;</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">is_successful</span><span class="col-meta">boolean</span></div>
+          <div class="col-desc">true = данные получены и сохранены, false = ошибка или пустой ответ</div>
+          <div class="col"><span class="col-icon">&middot;</span><span class="col-name">queried_at</span><span class="col-meta">timestamp</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div><!-- /groups -->
+
+
+<!-- FOREIGN KEYS -->
+<div class="relations">
+  <div class="relations-header">Все связи (Foreign Keys)</div>
+  <table class="rel-table">
+    <tr>
+      <th>Откуда</th><th></th><th>Куда</th><th>Тип</th><th>ON DELETE</th><th>Смысл связи</th>
+    </tr>
+    <tr>
+      <td><span class="rel-from">lattice_metadata.lattice_type_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">lattice_type.id</span></td>
+      <td class="rel-type">1 : 1</td>
+      <td><span class="on-del-cascade">CASCADE</span></td>
+      <td class="rel-desc">Один тип решётки = одна запись метаданных. Удалить тип &rarr; удалить метаданные</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">reference_structure.lattice_type_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">lattice_type.id</span></td>
+      <td class="rel-type">N : 1</td>
+      <td><span class="on-del-cascade">CASCADE</span></td>
+      <td class="rel-desc">Много структур принадлежат одной системе. NaCl, MgO, CaO &rarr; cubic</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">structure_site.structure_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">reference_structure.id</span></td>
+      <td class="rel-type">N : 1</td>
+      <td><span class="on-del-cascade">CASCADE</span></td>
+      <td class="rel-desc">Атомные позиции принадлежат структуре. NaCl: 57 строк. Удалить структуру &rarr; удалить все атомы</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">substance_info.structure_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">reference_structure.id</span></td>
+      <td class="rel-type">1 : 1</td>
+      <td><span class="on-del-cascade">CASCADE</span></td>
+      <td class="rel-desc">Одно описание на одно вещество (UNIQUE). Удалить структуру &rarr; удалить обогащение</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">recognition_result.session_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">recognition_session.id</span></td>
+      <td class="rel-type">N : 1</td>
+      <td><span class="on-del-cascade">CASCADE</span></td>
+      <td class="rel-desc">Один запрос &rarr; несколько результатов от COORD_MATCH и CATBOOST. Удалить сессию &rarr; удалить все её результаты</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">recognition_result.predicted_lattice_type_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">lattice_type.id</span></td>
+      <td class="rel-type">N : 1</td>
+      <td><span class="on-del-null">SET NULL</span></td>
+      <td class="rel-desc">Предсказанный тип решётки. SET NULL: исторические результаты не теряются при удалении типа</td>
+    </tr>
+    <tr>
+      <td><span class="rel-from">recognition_result.predicted_structure_id</span></td>
+      <td>&rarr;</td>
+      <td><span class="rel-to">reference_structure.id</span></td>
+      <td class="rel-type">N : 1</td>
+      <td><span class="on-del-null">SET NULL</span></td>
+      <td class="rel-desc">Конкретная структура-кандидат. NULL для CATBOOST (он предсказывает только тип, не вещество)</td>
+    </tr>
+  </table>
+</div>
+
+
+<!-- FLOWS -->
+<div style="margin-top:40px">
+  <div class="group-label">Потоки данных</div>
+  <div class="flows">
+
+    <div class="flow-card">
+      <div class="flow-title">&#128300; Загрузка структуры из COD</div>
+      <div class="flow-step"><div class="flow-num">1</div><div class="flow-text">CIF-файл &rarr; <strong>json_to_db.py</strong>: метаданные, формула, параметры ячейки, пространственная группа, cod_id</div></div>
+      <div class="flow-step"><div class="flow-num">2</div><div class="flow-text">INSERT в <strong>reference_structure</strong>. Дедупликация по cod_id &mdash; повторный импорт не создаст дубликат</div></div>
+      <div class="flow-step"><div class="flow-num">3</div><div class="flow-text">XYZ-файл с координатами &rarr; <strong>xyz_to_db.py</strong>: shift_coordinates + normalize_coordinates</div></div>
+      <div class="flow-step"><div class="flow-num">4</div><div class="flow-text">INSERT в <strong>structure_site</strong> (fract_x/y/z + norm_x/y/z) для каждого атома ячейки</div></div>
+    </div>
+
+    <div class="flow-card">
+      <div class="flow-title">&#129302; Обогащение вещества</div>
+      <div class="flow-step"><div class="flow-num">1</div><div class="flow-text"><strong>_load_crystal_properties()</strong>: параметры ячейки из reference_structure &rarr; <code>properties</code> JSONB</div></div>
+      <div class="flow-step"><div class="flow-num">2</div><div class="flow-text"><strong>CrossRef API</strong>: поиск топ-5 статей по запросу "name crystal structure lattice_type"</div></div>
+      <div class="flow-step"><div class="flow-num">3</div><div class="flow-text"><strong>OSTI API</strong>: публикации DOE, важно для UO&#8322;, UN, UC. Дедупликация по DOI с CrossRef</div></div>
+      <div class="flow-step"><div class="flow-num">4</div><div class="flow-text"><strong>GigaChat-2-Max</strong>: синтез description + applications + hazards на основе найденных статей</div></div>
+      <div class="flow-step"><div class="flow-num">5</div><div class="flow-text">UPSERT в <strong>substance_info</strong>. enrichment_source = "COD_PARAMS+CROSSREF+OSTI+AI"</div></div>
+    </div>
+
+    <div class="flow-card">
+      <div class="flow-title">&#129517; Распознавание: COORD_MATCH</div>
+      <div class="flow-step"><div class="flow-num">1</div><div class="flow-text">Пользователь вводит координаты &rarr; shift + normalize &rarr; нормализованные [0,1]</div></div>
+      <div class="flow-step"><div class="flow-num">2</div><div class="flow-text"><strong>get_similar_xyz_from_db()</strong>: SELECT по <strong>structure_site.norm_x/y/z</strong> BETWEEN x&plusmn;1e-4</div></div>
+      <div class="flow-step"><div class="flow-num">3</div><div class="flow-text"><strong>check_coords()</strong>: фильтр по количеству ионов, голосование, вероятности</div></div>
+      <div class="flow-step"><div class="flow-num">4</div><div class="flow-text">INSERT/GET в <strong>recognition_session</strong> (по SHA-256 хэшу) + INSERT в <strong>recognition_result</strong> rank=1</div></div>
+      <div class="flow-step"><div class="flow-num">5</div><div class="flow-text">Фоновый поток: <strong>enrich_substance()</strong> &rarr; substance_info (если ещё не обогащено)</div></div>
+    </div>
+
+    <div class="flow-card">
+      <div class="flow-title">&#129504; Распознавание: CATBOOST</div>
+      <div class="flow-step"><div class="flow-num">1</div><div class="flow-text">Те же нормализованные координаты &rarr; <strong>get_lattice_vectors3()</strong>: расстояния между всеми парами</div></div>
+      <div class="flow-step"><div class="flow-num">2</div><div class="flow-text"><strong>kde_array_1000()</strong>: KDE на 1000-точечной сетке [0,2]. Усреднение по ионам &rarr; вектор 1000-dim</div></div>
+      <div class="flow-step"><div class="flow-num">3</div><div class="flow-text"><strong>CatBoostClassifier</strong>: вероятности по 3 классам (cubic_f, cubic_p, hex_p)</div></div>
+      <div class="flow-step"><div class="flow-num">4</div><div class="flow-text"><strong>resolve_lattice_ids()</strong>: "cubic_f" &rarr; lattice_type.id через name_en</div></div>
+      <div class="flow-step"><div class="flow-num">5</div><div class="flow-text">Топ-3 в <strong>recognition_result</strong> (method=CATBOOST, predicted_structure_id=NULL)</div></div>
+    </div>
+
+    <div class="flow-card">
+      <div class="flow-title">&#128218; Обогащение типов решёток</div>
+      <div class="flow-step"><div class="flow-num">1</div><div class="flow-text">Ручной запуск <strong>enrich_all.py</strong> / <strong>enricher.py</strong> для каждого из 8 типов</div></div>
+      <div class="flow-step"><div class="flow-num">2</div><div class="flow-text"><strong>GigaChat-2-Max</strong>: JSON с coordination_number, packing_efficiency, typical_materials, applications, wiki_url</div></div>
+      <div class="flow-step"><div class="flow-num">3</div><div class="flow-text">UPSERT в <strong>lattice_metadata</strong> + запись в <strong>external_lookup_log</strong></div></div>
+    </div>
+
   </div>
 </div>
 
-<!-- lattice_metadata -->
-<div class="table t-ref" id="t-lattice_metadata" style="left:20px; top:340px;">
-  <div class="table-header">
-    <span class="icon">📖</span>
-    <span class="tname">lattice_metadata</span>
-    <span class="badge">обогащение</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk fk">lattice_type_id</span><span class="col-type">INT PK·FK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">discoverer</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">discovery_year</span><span class="col-type">SMALLINT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">discovery_context</span><span class="col-type">TEXT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">wiki_url</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">review_doi</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">notes</span><span class="col-type">TEXT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">enriched_at</span><span class="col-type">TIMESTAMP</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">enrichment_source</span><span class="col-type">VARCHAR</span></div>
-  </div>
-</div>
 
-<!-- ═══════════════════════════════════════════════════════════════
-     КОЛОНКА 2 — СТРУКТУРЫ
-═══════════════════════════════════════════════════════════════ -->
+<!-- NOTES -->
+<div style="margin-top:40px">
+  <div class="group-label">Известные проблемы и ограничения</div>
+  <div class="notes">
 
-<!-- reference_structure -->
-<div class="table t-struct" id="t-reference_structure" style="left:320px; top:40px;">
-  <div class="table-header">
-    <span class="icon">🧱</span>
-    <span class="tname">reference_structure</span>
-    <span class="badge">эталон</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
-    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">lattice_type_id</span><span class="col-type">INT FK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">name</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">formula</span><span class="col-type">VARCHAR</span></div>
-    <div class="col-divider"></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_length_a/b/c</span><span class="col-type">REAL</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_angle_α/β/γ</span><span class="col-type">REAL</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_volume</span><span class="col-type">REAL</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number / sg_hall / sg_hm</span><span class="col-type">VAR</span></div>
-    <div class="col-divider"></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">cif_path</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">xyz_path</span><span class="col-type">VARCHAR</span></div>
-    <div class="col-divider"></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">cod_id</span><span class="col-type">INT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">mp_id</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">doi</span><span class="col-type">VARCHAR</span></div>
-    <div class="col-divider"></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">existence_status</span><span class="col-type">ENUM</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">structure_description</span><span class="col-type">TEXT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">added_at / updated_at</span><span class="col-type">TS</span></div>
-  </div>
-</div>
+    <div class="note warn">
+      <div class="note-title">&#9888; Дубликаты структур</div>
+      <p>NaCl (id=3 synthetic + id=22 COD) и MgO (id=19 + id=25). COD хранит формулы алфавитно («Cl Na»), дедупликация по формуле не срабатывает. Нужно удалить синтетические записи без координат.</p>
+    </div>
 
-<!-- structure_site -->
-<div class="table t-struct" id="t-structure_site" style="left:320px; top:580px;">
-  <div class="table-header">
-    <span class="icon">⚛️</span>
-    <span class="tname">structure_site</span>
-    <span class="badge">ионы</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
-    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">structure_id</span><span class="col-type">INT FK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">atom_label</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">atom_symbol</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">oxidation / wyckoff</span><span class="col-type">REAL/VAR</span></div>
-    <div class="col-divider"></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">fract_x/y/z</span><span class="col-type">NUMERIC</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">norm_x/y/z</span><span class="col-type">NUMERIC</span></div>
+    <div class="note warn">
+      <div class="note-title">&#9888; Неверные типы у Fe и W</div>
+      <p>Записаны как <code>monoclinic</code>, должны быть <code>cubic</code>. Ошибка вошла при ручном заполнении через <code>complete_db.py</code>.</p>
+    </div>
+
+    <div class="note warn">
+      <div class="note-title">&#9888; 20 структур без координат</div>
+      <p>Синтетические записи id=2&ndash;21 (UO&#8322;, Fe, Al, Ti, UN &hellip;) имеют метаданные, но structure_site пустой. Поиск по ним невозможен до загрузки XYZ-файлов из COD.</p>
+    </div>
+
+    <div class="note warn">
+      <div class="note-title">&#9888; Изоструктурная неразличимость</div>
+      <p>NaCl, CaO, MgO, KCl &mdash; одинаковая rock-salt структура, одинаковые norm_x/y/z. COORD_MATCH не различает их без учёта атомных символов. Побеждает тот, у кого больше строк в structure_site.</p>
+    </div>
+
+    <div class="note warn">
+      <div class="note-title">&#9888; fract_x/y/z &mdash; название неточное</div>
+      <p>Хранят абсолютные координаты в &#8491;, а не дробные [0,1]. Нормализация делается отдельно в <code>norm_x/y/z</code>. На работу алгоритма не влияет.</p>
+    </div>
+
+    <div class="note warn">
+      <div class="note-title">&#9888; CatBoost &mdash; только 3 класса</div>
+      <p>Модель знает <code>cubic_f</code>, <code>cubic_p</code>, <code>hex_p</code>. Confidence всегда ~0.33 (равномерное). Нужна переобучка на полном датасете 8 систем. Интеграция с БД готова.</p>
+    </div>
+
+    <div class="note ok">
+      <div class="note-title">&#10003; feature_vector_cache готов к использованию</div>
+      <p>Схема правильная, таблица пустая. Подключить &mdash; одна строка в <code>ml_predict.py</code> после вычисления вектора.</p>
+    </div>
+
+    <div class="note info">
+      <div class="note-title">&#8505; NOT NULL везде</div>
+      <p>Все поля NOT NULL. Пустые значения хранятся как <code>''</code>, <code>{}</code> или <code>[]</code> в JSONB. Упрощает обработку в Python: нет проверок на None для строковых полей.</p>
+    </div>
+
+    <div class="note info">
+      <div class="note-title">&#8505; ON DELETE CASCADE vs SET NULL</div>
+      <p>CASCADE у структурных таблиц: удалить reference_structure &rarr; каскадно удалятся structure_site и substance_info. SET NULL у recognition_result: исторические результаты не теряются при удалении структуры из справочника.</p>
+    </div>
+
   </div>
 </div>
-
-<!-- ═══════════════════════════════════════════════════════════════
-     КОЛОНКА 3 — РАСПОЗНАВАНИЕ
-═══════════════════════════════════════════════════════════════ -->
-
-<!-- recognition_session -->
-<div class="table t-recog" id="t-recognition_session" style="left:640px; top:40px;">
-  <div class="table-header">
-    <span class="icon">🔍</span>
-    <span class="tname">recognition_session</span>
-    <span class="badge">сессия</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">UUID PK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">input_hash</span><span class="col-type">CHAR(64)</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">ion_count</span><span class="col-type">INT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">xyz_path</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">created_at</span><span class="col-type">TIMESTAMP</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">notes</span><span class="col-type">TEXT</span></div>
-  </div>
-</div>
-
-<!-- recognition_result -->
-<div class="table t-recog" id="t-recognition_result" style="left:640px; top:300px;">
-  <div class="table-header">
-    <span class="icon">🎯</span>
-    <span class="tname">recognition_result</span>
-    <span class="badge">результат</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
-    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">session_id</span><span class="col-type">UUID FK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">method</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">method_version</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">rank</span><span class="col-type">SMALLINT</span></div>
-    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">predicted_lattice_type_id</span><span class="col-type">INT FK</span></div>
-    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">predicted_structure_id</span><span class="col-type">INT FK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">confidence</span><span class="col-type">REAL</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">vector_path</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">computed_at</span><span class="col-type">TIMESTAMP</span></div>
-  </div>
-</div>
-
-<!-- feature_vector_cache -->
-<div class="table t-cache" id="t-feature_vector_cache" style="left:640px; top:620px;">
-  <div class="table-header">
-    <span class="icon">⚡</span>
-    <span class="tname">feature_vector_cache</span>
-    <span class="badge">кэш</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">input_hash</span><span class="col-type">CHAR(64) PK</span></div>
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">params_hash</span><span class="col-type">CHAR(64) PK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">method_name</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">vector_path</span><span class="col-type">VARCHAR</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">ion_count</span><span class="col-type">INT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">computed_at</span><span class="col-type">TIMESTAMP</span></div>
-  </div>
-</div>
-
-<!-- ═══════════════════════════════════════════════════════════════
-     КОЛОНКА 4 — ЛОГ
-═══════════════════════════════════════════════════════════════ -->
-
-<!-- external_lookup_log -->
-<div class="table t-log" id="t-external_lookup_log" style="left:950px; top:40px;">
-  <div class="table-header">
-    <span class="icon">📋</span>
-    <span class="tname">external_lookup_log</span>
-    <span class="badge">лог API</span>
-  </div>
-  <div class="table-body">
-    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">source</span><span class="col-type">ENUM</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">target_type</span><span class="col-type">ENUM</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">target_id</span><span class="col-type">INT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">query_text</span><span class="col-type">TEXT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">result_summary</span><span class="col-type">TEXT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name important">enriched_fields</span><span class="col-type">JSONB</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">http_status</span><span class="col-type">SMALLINT</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">is_successful</span><span class="col-type">BOOLEAN</span></div>
-    <div class="col"><span class="col-icon"> </span><span class="col-name">queried_at</span><span class="col-type">TIMESTAMP</span></div>
-  </div>
-</div>
-
-<!-- ENUM legend -->
-<div style="position:absolute; left:950px; top:350px; width:220px; background:#1a1d27; border-radius:8px; padding:14px; border:1px solid rgba(255,255,255,0.06);">
-  <div style="font-size:11px; font-weight:700; color:#f59e0b; letter-spacing:1px; margin-bottom:10px;">ENUM ТИПЫ</div>
-  <div style="font-size:11px; color:#64748b; margin-bottom:6px; font-weight:600;">existence_status_t</div>
-  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">experimental<br>theoretical<br>hypothetical<br>disputed</div>
-  <div style="font-size:11px; color:#64748b; margin:8px 0 6px; font-weight:600;">lookup_source_t</div>
-  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">COD · MATERIALS_PROJECT<br>ICSD · CROSSREF<br>AI_SEARCH · MANUAL</div>
-  <div style="font-size:11px; color:#64748b; margin:8px 0 6px; font-weight:600;">lookup_target_t</div>
-  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">lattice_type<br>reference_structure</div>
-</div>
-
-<!-- INDEXES legend -->
-<div style="position:absolute; left:950px; top:600px; width:220px; background:#1a1d27; border-radius:8px; padding:14px; border:1px solid rgba(255,255,255,0.06);">
-  <div style="font-size:11px; font-weight:700; color:#14b8a6; letter-spacing:1px; margin-bottom:10px;">ИНДЕКСЫ</div>
-  <div style="font-size:10.5px; color:#94a3b8; line-height:2.0; font-family:Consolas,monospace;">
-    idx_norm<br>
-    <span style="color:#475569; padding-left:8px">structure_site(norm_x,y,z)</span><br>
-    idx_structure<br>
-    <span style="color:#475569; padding-left:8px">structure_site(structure_id)</span><br>
-    idx_session_hash<br>
-    <span style="color:#475569; padding-left:8px">recognition_session(input_hash)</span>
-  </div>
-</div>
-
-</div><!-- /canvas -->
-
-<script>
-// Рисуем стрелки между таблицами после рендера
-window.addEventListener('load', () => {
-  const svg = document.getElementById('svg');
-  const canvas = document.getElementById('canvas');
-  const cr = canvas.getBoundingClientRect();
-
-  function getBox(id) {
-    const el = document.getElementById(id);
-    const r = el.getBoundingClientRect();
-    return {
-      x: r.left - cr.left,
-      y: r.top  - cr.top,
-      w: r.width,
-      h: r.height,
-      cx: r.left - cr.left + r.width / 2,
-      cy: r.top  - cr.top  + r.height / 2,
-      right:  r.left - cr.left + r.width,
-      bottom: r.top  - cr.top  + r.height,
-    };
-  }
-
-  function arrow(x1, y1, x2, y2, color, marker, dashed) {
-    const dx = x2 - x1, dy = y2 - y1;
-    const mx = x1 + dx * 0.5, my = y1 + dy * 0.5;
-    const path = document.createElementNS('http://www.w3.org/2000/svg','path');
-
-    // Кривая Безье
-    let d;
-    if (Math.abs(dx) > Math.abs(dy)) {
-      d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
-    } else {
-      d = `M${x1},${y1} C${x1},${my} ${x2},${my} ${x2},${y2}`;
-    }
-
-    path.setAttribute('d', d);
-    path.setAttribute('stroke', color);
-    path.setAttribute('stroke-width', '1.8');
-    path.setAttribute('fill', 'none');
-    path.setAttribute('opacity', '0.6');
-    path.setAttribute('marker-end', `url(#${marker})`);
-    if (dashed) path.setAttribute('stroke-dasharray', '5,3');
-    svg.appendChild(path);
-  }
-
-  // lattice_type → lattice_metadata (вниз по левой стороне)
-  const lt  = getBox('t-lattice_type');
-  const lm  = getBox('t-lattice_metadata');
-  arrow(lt.cx, lt.bottom, lm.cx, lm.y, '#3b82f6', 'arr-blue', false);
-
-  // lattice_type → reference_structure (вправо)
-  const rs  = getBox('t-reference_structure');
-  arrow(lt.right, lt.cy - 20, rs.x, rs.y + 55, '#3b82f6', 'arr-blue', false);
-
-  // reference_structure → structure_site (вниз)
-  const ss  = getBox('t-structure_site');
-  arrow(rs.cx, rs.bottom, ss.cx, ss.y, '#22c55e', 'arr-green', false);
-
-  // recognition_session → recognition_result (вниз)
-  const ses = getBox('t-recognition_session');
-  const rr  = getBox('t-recognition_result');
-  arrow(ses.cx, ses.bottom, rr.cx, rr.y, '#a855f7', 'arr-purple', false);
-
-  // recognition_result → lattice_type (дугой влево)
-  arrow(rr.x, rr.cy - 30, lt.right + 5, lt.cy + 60, '#818cf8', 'arr-blue', true);
-
-  // recognition_result → reference_structure
-  arrow(rr.x, rr.cy + 10, rs.right, rs.cy + 80, '#22c55e', 'arr-green', true);
-
-  // lattice_type → external_lookup_log (вправо наверх)
-  const log = getBox('t-external_lookup_log');
-  arrow(lt.right, lt.cy - 60, log.x, log.y + 40, '#f59e0b', 'arr-amber', true);
-
-  // reference_structure → external_lookup_log (вправо)
-  arrow(rs.right + 5, rs.cy - 40, log.x, log.cy - 60, '#f59e0b', 'arr-amber', true);
-});
-</script>
 
 </body>
 </html>

--- a/docs/db_schema.html
+++ b/docs/db_schema.html
@@ -1,0 +1,507 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>crystal_lattice_db — схема БД</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: #0f1117;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    color: #e2e8f0;
+    min-height: 100vh;
+    padding: 32px;
+  }
+
+  h1 {
+    text-align: center;
+    font-size: 22px;
+    font-weight: 600;
+    color: #94a3b8;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .subtitle {
+    text-align: center;
+    font-size: 13px;
+    color: #475569;
+    margin-bottom: 40px;
+    letter-spacing: 1px;
+  }
+
+  /* ── ЛЕГЕНДА ─────────────────────────────────────── */
+  .legend {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    margin-bottom: 36px;
+    flex-wrap: wrap;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: #94a3b8;
+  }
+  .legend-dot {
+    width: 12px; height: 12px;
+    border-radius: 3px;
+  }
+
+  /* ── CANVAS ──────────────────────────────────────── */
+  .canvas {
+    position: relative;
+    width: 1200px;
+    margin: 0 auto;
+    height: 860px;
+  }
+
+  svg.lines {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    pointer-events: none;
+    overflow: visible;
+  }
+
+  /* ── ТАБЛИЦА ─────────────────────────────────────── */
+  .table {
+    position: absolute;
+    width: 240px;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.5);
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+
+  .table-header {
+    padding: 10px 14px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .table-header .icon { font-size: 15px; }
+  .table-header .tname { flex: 1; }
+  .table-header .badge {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: rgba(0,0,0,0.25);
+    opacity: 0.8;
+  }
+
+  .table-body {
+    background: #1a1d27;
+  }
+
+  .col {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 14px;
+    font-size: 11.5px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+    transition: background 0.15s;
+  }
+  .col:hover { background: rgba(255,255,255,0.04); }
+  .col:last-child { border-bottom: none; }
+
+  .col-icon {
+    width: 14px;
+    text-align: center;
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+  .col-name {
+    flex: 1;
+    color: #cbd5e1;
+  }
+  .col-name.pk { color: #fbbf24; font-weight: 600; }
+  .col-name.fk { color: #818cf8; }
+  .col-name.important { color: #e2e8f0; font-weight: 500; }
+
+  .col-type {
+    font-size: 10px;
+    color: #475569;
+    font-family: 'Consolas', monospace;
+    flex-shrink: 0;
+  }
+
+  .col-divider {
+    height: 1px;
+    background: rgba(255,255,255,0.08);
+    margin: 2px 0;
+  }
+
+  /* ── ЦВЕТА ТАБЛИЦ ────────────────────────────────── */
+  /* справочник */
+  .t-ref .table-header    { background: #1e3a5f; }
+  .t-ref .table-header    { border-bottom: 2px solid #3b82f6; }
+  /* структуры */
+  .t-struct .table-header { background: #14532d; border-bottom: 2px solid #22c55e; }
+  /* распознавание */
+  .t-recog .table-header  { background: #3b1f5e; border-bottom: 2px solid #a855f7; }
+  /* кэш */
+  .t-cache .table-header  { background: #1c3a3a; border-bottom: 2px solid #14b8a6; }
+  /* лог */
+  .t-log .table-header    { background: #3b2a14; border-bottom: 2px solid #f59e0b; }
+
+  /* ── СВЯЗИ ───────────────────────────────────────── */
+  .rel-line {
+    stroke-width: 1.5;
+    fill: none;
+    opacity: 0.55;
+  }
+  .rel-fk    { stroke: #818cf8; stroke-dasharray: none; }
+  .rel-set   { stroke: #f59e0b; stroke-dasharray: 5,3; }
+
+  .rel-label {
+    font-size: 10px;
+    fill: #64748b;
+    font-family: 'Segoe UI', sans-serif;
+  }
+
+  marker path { stroke: none; }
+
+  /* ── СЕКЦИИ (группировка) ────────────────────────── */
+  .section-label {
+    position: absolute;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #334155;
+  }
+</style>
+</head>
+<body>
+
+<h1>crystal_lattice_db</h1>
+<div class="subtitle">PostgreSQL · 8 таблиц · feature/database-redesign</div>
+
+<div class="legend">
+  <div class="legend-item"><div class="legend-dot" style="background:#3b82f6"></div> Справочник решёток</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#22c55e"></div> Эталонные структуры</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#a855f7"></div> Распознавание</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#14b8a6"></div> Кэш векторов</div>
+  <div class="legend-item"><div class="legend-dot" style="background:#f59e0b"></div> Лог запросов</div>
+</div>
+
+<div class="canvas" id="canvas">
+
+<!-- ── SVG СВЯЗИ ──────────────────────────────────────────────────── -->
+<svg class="lines" id="svg">
+  <defs>
+    <marker id="arr-blue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#818cf8"/>
+    </marker>
+    <marker id="arr-amber" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#f59e0b"/>
+    </marker>
+    <marker id="arr-green" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#22c55e"/>
+    </marker>
+    <marker id="arr-purple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#a855f7"/>
+    </marker>
+    <marker id="arr-teal" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#14b8a6"/>
+    </marker>
+  </defs>
+</svg>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     КОЛОНКА 1 — СПРАВОЧНИК РЕШЁТОК
+═══════════════════════════════════════════════════════════════ -->
+
+<!-- lattice_type -->
+<div class="table t-ref" id="t-lattice_type" style="left:20px; top:40px;">
+  <div class="table-header">
+    <span class="icon">🔷</span>
+    <span class="tname">lattice_type</span>
+    <span class="badge">справочник</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">name_en</span><span class="col-type">VARCHAR UNIQUE</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">name_ru</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">crystal_system</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">bravais_lattice</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">point_group</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number_min</span><span class="col-type">SMALLINT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number_max</span><span class="col-type">SMALLINT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">description</span><span class="col-type">TEXT</span></div>
+  </div>
+</div>
+
+<!-- lattice_metadata -->
+<div class="table t-ref" id="t-lattice_metadata" style="left:20px; top:340px;">
+  <div class="table-header">
+    <span class="icon">📖</span>
+    <span class="tname">lattice_metadata</span>
+    <span class="badge">обогащение</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk fk">lattice_type_id</span><span class="col-type">INT PK·FK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">discoverer</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">discovery_year</span><span class="col-type">SMALLINT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">discovery_context</span><span class="col-type">TEXT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">wiki_url</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">review_doi</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">notes</span><span class="col-type">TEXT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">enriched_at</span><span class="col-type">TIMESTAMP</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">enrichment_source</span><span class="col-type">VARCHAR</span></div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     КОЛОНКА 2 — СТРУКТУРЫ
+═══════════════════════════════════════════════════════════════ -->
+
+<!-- reference_structure -->
+<div class="table t-struct" id="t-reference_structure" style="left:320px; top:40px;">
+  <div class="table-header">
+    <span class="icon">🧱</span>
+    <span class="tname">reference_structure</span>
+    <span class="badge">эталон</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
+    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">lattice_type_id</span><span class="col-type">INT FK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">name</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">formula</span><span class="col-type">VARCHAR</span></div>
+    <div class="col-divider"></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_length_a/b/c</span><span class="col-type">REAL</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_angle_α/β/γ</span><span class="col-type">REAL</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">cell_volume</span><span class="col-type">REAL</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">sg_number / sg_hall / sg_hm</span><span class="col-type">VAR</span></div>
+    <div class="col-divider"></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">cif_path</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">xyz_path</span><span class="col-type">VARCHAR</span></div>
+    <div class="col-divider"></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">cod_id</span><span class="col-type">INT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">mp_id</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">doi</span><span class="col-type">VARCHAR</span></div>
+    <div class="col-divider"></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">existence_status</span><span class="col-type">ENUM</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">structure_description</span><span class="col-type">TEXT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">added_at / updated_at</span><span class="col-type">TS</span></div>
+  </div>
+</div>
+
+<!-- structure_site -->
+<div class="table t-struct" id="t-structure_site" style="left:320px; top:580px;">
+  <div class="table-header">
+    <span class="icon">⚛️</span>
+    <span class="tname">structure_site</span>
+    <span class="badge">ионы</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
+    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">structure_id</span><span class="col-type">INT FK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">atom_label</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">atom_symbol</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">oxidation / wyckoff</span><span class="col-type">REAL/VAR</span></div>
+    <div class="col-divider"></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">fract_x/y/z</span><span class="col-type">NUMERIC</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">norm_x/y/z</span><span class="col-type">NUMERIC</span></div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     КОЛОНКА 3 — РАСПОЗНАВАНИЕ
+═══════════════════════════════════════════════════════════════ -->
+
+<!-- recognition_session -->
+<div class="table t-recog" id="t-recognition_session" style="left:640px; top:40px;">
+  <div class="table-header">
+    <span class="icon">🔍</span>
+    <span class="tname">recognition_session</span>
+    <span class="badge">сессия</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">UUID PK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">input_hash</span><span class="col-type">CHAR(64)</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">ion_count</span><span class="col-type">INT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">xyz_path</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">created_at</span><span class="col-type">TIMESTAMP</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">notes</span><span class="col-type">TEXT</span></div>
+  </div>
+</div>
+
+<!-- recognition_result -->
+<div class="table t-recog" id="t-recognition_result" style="left:640px; top:300px;">
+  <div class="table-header">
+    <span class="icon">🎯</span>
+    <span class="tname">recognition_result</span>
+    <span class="badge">результат</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
+    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">session_id</span><span class="col-type">UUID FK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">method</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">method_version</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">rank</span><span class="col-type">SMALLINT</span></div>
+    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">predicted_lattice_type_id</span><span class="col-type">INT FK</span></div>
+    <div class="col"><span class="col-icon">🔗</span><span class="col-name fk">predicted_structure_id</span><span class="col-type">INT FK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">confidence</span><span class="col-type">REAL</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">vector_path</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">computed_at</span><span class="col-type">TIMESTAMP</span></div>
+  </div>
+</div>
+
+<!-- feature_vector_cache -->
+<div class="table t-cache" id="t-feature_vector_cache" style="left:640px; top:620px;">
+  <div class="table-header">
+    <span class="icon">⚡</span>
+    <span class="tname">feature_vector_cache</span>
+    <span class="badge">кэш</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">input_hash</span><span class="col-type">CHAR(64) PK</span></div>
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">params_hash</span><span class="col-type">CHAR(64) PK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">method_name</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">vector_path</span><span class="col-type">VARCHAR</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">ion_count</span><span class="col-type">INT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">computed_at</span><span class="col-type">TIMESTAMP</span></div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     КОЛОНКА 4 — ЛОГ
+═══════════════════════════════════════════════════════════════ -->
+
+<!-- external_lookup_log -->
+<div class="table t-log" id="t-external_lookup_log" style="left:950px; top:40px;">
+  <div class="table-header">
+    <span class="icon">📋</span>
+    <span class="tname">external_lookup_log</span>
+    <span class="badge">лог API</span>
+  </div>
+  <div class="table-body">
+    <div class="col"><span class="col-icon">🔑</span><span class="col-name pk">id</span><span class="col-type">SERIAL PK</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">source</span><span class="col-type">ENUM</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">target_type</span><span class="col-type">ENUM</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">target_id</span><span class="col-type">INT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">query_text</span><span class="col-type">TEXT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">result_summary</span><span class="col-type">TEXT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name important">enriched_fields</span><span class="col-type">JSONB</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">http_status</span><span class="col-type">SMALLINT</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">is_successful</span><span class="col-type">BOOLEAN</span></div>
+    <div class="col"><span class="col-icon"> </span><span class="col-name">queried_at</span><span class="col-type">TIMESTAMP</span></div>
+  </div>
+</div>
+
+<!-- ENUM legend -->
+<div style="position:absolute; left:950px; top:350px; width:220px; background:#1a1d27; border-radius:8px; padding:14px; border:1px solid rgba(255,255,255,0.06);">
+  <div style="font-size:11px; font-weight:700; color:#f59e0b; letter-spacing:1px; margin-bottom:10px;">ENUM ТИПЫ</div>
+  <div style="font-size:11px; color:#64748b; margin-bottom:6px; font-weight:600;">existence_status_t</div>
+  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">experimental<br>theoretical<br>hypothetical<br>disputed</div>
+  <div style="font-size:11px; color:#64748b; margin:8px 0 6px; font-weight:600;">lookup_source_t</div>
+  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">COD · MATERIALS_PROJECT<br>ICSD · CROSSREF<br>AI_SEARCH · MANUAL</div>
+  <div style="font-size:11px; color:#64748b; margin:8px 0 6px; font-weight:600;">lookup_target_t</div>
+  <div style="font-size:10.5px; color:#94a3b8; padding-left:8px; line-height:1.8;">lattice_type<br>reference_structure</div>
+</div>
+
+<!-- INDEXES legend -->
+<div style="position:absolute; left:950px; top:600px; width:220px; background:#1a1d27; border-radius:8px; padding:14px; border:1px solid rgba(255,255,255,0.06);">
+  <div style="font-size:11px; font-weight:700; color:#14b8a6; letter-spacing:1px; margin-bottom:10px;">ИНДЕКСЫ</div>
+  <div style="font-size:10.5px; color:#94a3b8; line-height:2.0; font-family:Consolas,monospace;">
+    idx_norm<br>
+    <span style="color:#475569; padding-left:8px">structure_site(norm_x,y,z)</span><br>
+    idx_structure<br>
+    <span style="color:#475569; padding-left:8px">structure_site(structure_id)</span><br>
+    idx_session_hash<br>
+    <span style="color:#475569; padding-left:8px">recognition_session(input_hash)</span>
+  </div>
+</div>
+
+</div><!-- /canvas -->
+
+<script>
+// Рисуем стрелки между таблицами после рендера
+window.addEventListener('load', () => {
+  const svg = document.getElementById('svg');
+  const canvas = document.getElementById('canvas');
+  const cr = canvas.getBoundingClientRect();
+
+  function getBox(id) {
+    const el = document.getElementById(id);
+    const r = el.getBoundingClientRect();
+    return {
+      x: r.left - cr.left,
+      y: r.top  - cr.top,
+      w: r.width,
+      h: r.height,
+      cx: r.left - cr.left + r.width / 2,
+      cy: r.top  - cr.top  + r.height / 2,
+      right:  r.left - cr.left + r.width,
+      bottom: r.top  - cr.top  + r.height,
+    };
+  }
+
+  function arrow(x1, y1, x2, y2, color, marker, dashed) {
+    const dx = x2 - x1, dy = y2 - y1;
+    const mx = x1 + dx * 0.5, my = y1 + dy * 0.5;
+    const path = document.createElementNS('http://www.w3.org/2000/svg','path');
+
+    // Кривая Безье
+    let d;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
+    } else {
+      d = `M${x1},${y1} C${x1},${my} ${x2},${my} ${x2},${y2}`;
+    }
+
+    path.setAttribute('d', d);
+    path.setAttribute('stroke', color);
+    path.setAttribute('stroke-width', '1.8');
+    path.setAttribute('fill', 'none');
+    path.setAttribute('opacity', '0.6');
+    path.setAttribute('marker-end', `url(#${marker})`);
+    if (dashed) path.setAttribute('stroke-dasharray', '5,3');
+    svg.appendChild(path);
+  }
+
+  // lattice_type → lattice_metadata (вниз по левой стороне)
+  const lt  = getBox('t-lattice_type');
+  const lm  = getBox('t-lattice_metadata');
+  arrow(lt.cx, lt.bottom, lm.cx, lm.y, '#3b82f6', 'arr-blue', false);
+
+  // lattice_type → reference_structure (вправо)
+  const rs  = getBox('t-reference_structure');
+  arrow(lt.right, lt.cy - 20, rs.x, rs.y + 55, '#3b82f6', 'arr-blue', false);
+
+  // reference_structure → structure_site (вниз)
+  const ss  = getBox('t-structure_site');
+  arrow(rs.cx, rs.bottom, ss.cx, ss.y, '#22c55e', 'arr-green', false);
+
+  // recognition_session → recognition_result (вниз)
+  const ses = getBox('t-recognition_session');
+  const rr  = getBox('t-recognition_result');
+  arrow(ses.cx, ses.bottom, rr.cx, rr.y, '#a855f7', 'arr-purple', false);
+
+  // recognition_result → lattice_type (дугой влево)
+  arrow(rr.x, rr.cy - 30, lt.right + 5, lt.cy + 60, '#818cf8', 'arr-blue', true);
+
+  // recognition_result → reference_structure
+  arrow(rr.x, rr.cy + 10, rs.right, rs.cy + 80, '#22c55e', 'arr-green', true);
+
+  // lattice_type → external_lookup_log (вправо наверх)
+  const log = getBox('t-external_lookup_log');
+  arrow(lt.right, lt.cy - 60, log.x, log.y + 40, '#f59e0b', 'arr-amber', true);
+
+  // reference_structure → external_lookup_log (вправо)
+  arrow(rs.right + 5, rs.cy - 40, log.x, log.cy - 60, '#f59e0b', 'arr-amber', true);
+});
+</script>
+
+</body>
+</html>

--- a/docs/ui_mockup.html
+++ b/docs/ui_mockup.html
@@ -1,0 +1,518 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>CRIS — UI Mockup</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'Segoe UI', sans-serif; background: #0d1117; color: #e6edf3; height: 100vh; display: flex; flex-direction: column; }
+
+  /* ── Header ── */
+  .header {
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+  .header .logo { font-size: 20px; font-weight: 700; color: #58a6ff; letter-spacing: 2px; }
+  .header .subtitle { font-size: 12px; color: #8b949e; }
+  .header .spacer { flex: 1; }
+  .header .status { font-size: 12px; color: #3fb950; display: flex; align-items: center; gap: 6px; }
+  .header .status::before { content: '●'; }
+  .btn-icon {
+    background: #21262d;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #8b949e;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .btn-icon:hover { background: #30363d; color: #e6edf3; }
+
+  /* ── Layout ── */
+  .workspace { display: flex; flex: 1; overflow: hidden; }
+
+  /* ── Left Sidebar ── */
+  .sidebar {
+    width: 280px;
+    background: #161b22;
+    border-right: 1px solid #30363d;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    overflow-y: auto;
+  }
+  .sidebar-section { padding: 16px; border-bottom: 1px solid #21262d; }
+  .sidebar-section label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    display: block;
+    margin-bottom: 8px;
+  }
+  .select {
+    width: 100%;
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #e6edf3;
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+  .ion-list { display: flex; flex-direction: column; gap: 4px; margin-top: 8px; }
+  .ion-item {
+    display: flex;
+    align-items: center;
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 8px 10px;
+    cursor: pointer;
+    gap: 8px;
+    font-size: 13px;
+    transition: border-color 0.15s;
+  }
+  .ion-item:hover { border-color: #58a6ff; }
+  .ion-item.filled { border-color: #3fb950; }
+  .ion-item .ion-num {
+    background: #21262d;
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 11px;
+    color: #8b949e;
+  }
+  .ion-item .ion-coords { font-size: 11px; color: #8b949e; }
+  .ion-item.filled .ion-coords { color: #3fb950; }
+  .ion-item .ion-dot { width: 6px; height: 6px; border-radius: 50%; background: #30363d; margin-left: auto; }
+  .ion-item.filled .ion-dot { background: #3fb950; }
+
+  .btn-load {
+    width: 100%;
+    background: #21262d;
+    border: 1px dashed #30363d;
+    border-radius: 6px;
+    color: #8b949e;
+    padding: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    text-align: center;
+    margin-top: 8px;
+  }
+  .btn-load:hover { border-color: #58a6ff; color: #58a6ff; }
+
+  .sidebar-actions { padding: 16px; margin-top: auto; display: flex; flex-direction: column; gap: 8px; }
+
+  .btn-primary {
+    background: #238636;
+    border: none;
+    border-radius: 6px;
+    color: #fff;
+    padding: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  .btn-primary:hover { background: #2ea043; }
+  .btn-secondary {
+    background: #21262d;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #e6edf3;
+    padding: 8px;
+    font-size: 13px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+  .btn-secondary:hover { background: #30363d; }
+  .btn-danger {
+    background: transparent;
+    border: 1px solid #f85149;
+    border-radius: 6px;
+    color: #f85149;
+    padding: 8px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .btn-danger:hover { background: #f8514920; }
+
+  /* ── Main Content ── */
+  .main { flex: 1; overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 16px; }
+
+  /* Empty state */
+  .empty-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #484f58;
+    gap: 12px;
+    text-align: center;
+  }
+  .empty-state .icon { font-size: 48px; }
+  .empty-state p { font-size: 14px; }
+
+  /* Cards */
+  .card {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .card-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid #21262d;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .card-header .card-title { font-size: 13px; font-weight: 600; color: #8b949e; text-transform: uppercase; letter-spacing: 0.6px; }
+  .card-body { padding: 16px; }
+
+  /* Lattice result card */
+  .lattice-result {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+  }
+  .lattice-image {
+    width: 100px;
+    height: 100px;
+    background: #21262d;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #8b949e;
+    font-size: 11px;
+    flex-shrink: 0;
+    border: 1px solid #30363d;
+  }
+  .lattice-info { flex: 1; }
+  .lattice-name { font-size: 22px; font-weight: 700; color: #e6edf3; margin-bottom: 4px; }
+  .lattice-en { font-size: 13px; color: #8b949e; margin-bottom: 12px; }
+  .badges { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+  .badge {
+    padding: 3px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .badge-blue { background: #1f6feb33; border: 1px solid #1f6feb; color: #58a6ff; }
+  .badge-green { background: #23863633; border: 1px solid #238636; color: #3fb950; }
+  .badge-purple { background: #8957e533; border: 1px solid #8957e5; color: #bc8cff; }
+  .badge-orange { background: #d2930033; border: 1px solid #d29300; color: #e3b341; }
+
+  .confidence-bar-wrap { margin-bottom: 12px; }
+  .confidence-label { font-size: 12px; color: #8b949e; margin-bottom: 4px; display: flex; justify-content: space-between; }
+  .confidence-bar { height: 6px; background: #21262d; border-radius: 3px; overflow: hidden; }
+  .confidence-fill { height: 100%; background: linear-gradient(90deg, #238636, #3fb950); border-radius: 3px; }
+
+  .meta-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .meta-item { background: #0d1117; border-radius: 6px; padding: 8px 10px; }
+  .meta-item .meta-label { font-size: 10px; color: #8b949e; margin-bottom: 2px; }
+  .meta-item .meta-value { font-size: 13px; color: #e6edf3; font-weight: 500; }
+
+  /* Substance card */
+  .substance-name { font-size: 18px; font-weight: 700; margin-bottom: 4px; }
+  .substance-formula {
+    font-size: 14px; color: #8b949e; margin-bottom: 12px;
+    font-family: monospace;
+  }
+  .substance-desc { font-size: 13px; color: #b0bec5; line-height: 1.6; margin-bottom: 12px; }
+  .substance-sections { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .substance-section { background: #0d1117; border-radius: 6px; padding: 12px; }
+  .substance-section .sec-title { font-size: 11px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 8px; }
+  .substance-section .sec-content { font-size: 13px; color: #e6edf3; line-height: 1.5; }
+  .hazard-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #f8514920;
+    border: 1px solid #f85149;
+    color: #f85149;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 13px;
+    margin-top: 8px;
+  }
+
+  /* Properties */
+  .props-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .prop-item { background: #0d1117; border-radius: 6px; padding: 10px 12px; }
+  .prop-label { font-size: 11px; color: #8b949e; margin-bottom: 3px; }
+  .prop-value { font-size: 14px; color: #e6edf3; font-weight: 500; }
+
+  /* Candidates */
+  .candidates { display: flex; flex-direction: column; gap: 6px; }
+  .candidate-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: #0d1117;
+    border-radius: 6px;
+    border: 1px solid #21262d;
+  }
+  .candidate-item.top { border-color: #238636; background: #23863610; }
+  .candidate-rank { font-size: 11px; color: #8b949e; width: 20px; }
+  .candidate-name { font-size: 13px; flex: 1; }
+  .candidate-pct { font-size: 13px; font-weight: 600; color: #3fb950; }
+  .candidate-bar-wrap { width: 80px; }
+  .candidate-bar { height: 4px; background: #21262d; border-radius: 2px; }
+  .candidate-bar-fill { height: 100%; background: #3fb950; border-radius: 2px; }
+  .candidate-item:not(.top) .candidate-pct { color: #8b949e; }
+  .candidate-item:not(.top) .candidate-bar-fill { background: #30363d; }
+
+  /* Sources */
+  .sources-list { display: flex; flex-direction: column; gap: 8px; }
+  .source-item {
+    padding: 10px 12px;
+    background: #0d1117;
+    border-radius: 6px;
+    border-left: 3px solid #1f6feb;
+  }
+  .source-title { font-size: 13px; color: #58a6ff; margin-bottom: 3px; cursor: pointer; }
+  .source-title:hover { text-decoration: underline; }
+  .source-meta { font-size: 11px; color: #8b949e; display: flex; gap: 10px; margin-bottom: 4px; }
+  .source-snippet { font-size: 11px; color: #6e7681; line-height: 1.4; }
+  .source-tag {
+    display: inline-block;
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-left: 4px;
+  }
+  .tag-osti { background: #1f6feb33; color: #58a6ff; }
+  .tag-crossref { background: #8957e533; color: #bc8cff; }
+</style>
+</head>
+<body>
+
+<!-- Header -->
+<div class="header">
+  <span class="logo">CRIS</span>
+  <span class="subtitle">Crystal Recognition & Identification System</span>
+  <div class="spacer"></div>
+  <span class="status">БД подключена</span>
+  <button class="btn-icon">⚙ Настройки</button>
+  <button class="btn-icon">? Справка</button>
+</div>
+
+<!-- Workspace -->
+<div class="workspace">
+
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="sidebar-section">
+      <label>Количество ионов</label>
+      <select class="select">
+        <option>Выберите количество...</option>
+        <option selected>4 иона</option>
+      </select>
+    </div>
+
+    <div class="sidebar-section">
+      <label>Координаты ионов</label>
+      <div class="ion-list">
+        <div class="ion-item filled">
+          <span class="ion-num">1</span>
+          <span class="ion-coords">0.00 / 0.00 / 0.00</span>
+          <span class="ion-dot"></span>
+        </div>
+        <div class="ion-item filled">
+          <span class="ion-num">2</span>
+          <span class="ion-coords">0.50 / 0.50 / 0.00</span>
+          <span class="ion-dot"></span>
+        </div>
+        <div class="ion-item filled">
+          <span class="ion-num">3</span>
+          <span class="ion-coords">0.50 / 0.00 / 0.50</span>
+          <span class="ion-dot"></span>
+        </div>
+        <div class="ion-item">
+          <span class="ion-num">4</span>
+          <span class="ion-coords">не задан</span>
+          <span class="ion-dot"></span>
+        </div>
+      </div>
+      <div class="btn-load">⬆ Загрузить из CSV / XYZ</div>
+    </div>
+
+    <div class="sidebar-actions">
+      <button class="btn-primary">▶ Распознать</button>
+      <button class="btn-secondary">💾 Сохранить отчёт</button>
+      <button class="btn-danger">↺ Сбросить</button>
+    </div>
+  </div>
+
+  <!-- Main -->
+  <div class="main">
+
+    <!-- Lattice type result -->
+    <div class="card">
+      <div class="card-header">
+        <span>🔷</span>
+        <span class="card-title">Тип кристаллической решётки</span>
+      </div>
+      <div class="card-body">
+        <div class="lattice-result">
+          <div class="lattice-image">изображение<br>решётки</div>
+          <div class="lattice-info">
+            <div class="lattice-name">Кубическая гранецентрированная</div>
+            <div class="lattice-en">Cubic Face-Centered (FCC) · cubic</div>
+            <div class="badges">
+              <span class="badge badge-blue">Пр. группа: Fm3̄m (225)</span>
+              <span class="badge badge-purple">Браве: F</span>
+              <span class="badge badge-orange">КЧ = 12</span>
+              <span class="badge badge-green">η = 0.74</span>
+            </div>
+            <div class="confidence-bar-wrap">
+              <div class="confidence-label">
+                <span>Уверенность распознавания</span>
+                <span style="color:#3fb950;font-weight:600;">94.2%</span>
+              </div>
+              <div class="confidence-bar"><div class="confidence-fill" style="width:94.2%"></div></div>
+            </div>
+            <div class="meta-grid">
+              <div class="meta-item">
+                <div class="meta-label">Система</div>
+                <div class="meta-value">Кубическая</div>
+              </div>
+              <div class="meta-item">
+                <div class="meta-label">Типичные материалы</div>
+                <div class="meta-value">Al, Cu, Au, Ni</div>
+              </div>
+              <div class="meta-item">
+                <div class="meta-label">Пр. группы ITA</div>
+                <div class="meta-value">195 – 230</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Candidates -->
+    <div class="card">
+      <div class="card-header">
+        <span>📊</span>
+        <span class="card-title">Все варианты распознавания</span>
+      </div>
+      <div class="card-body">
+        <div class="candidates">
+          <div class="candidate-item top">
+            <span class="candidate-rank">#1</span>
+            <span class="candidate-name">Кубическая гранецентрированная (FCC)</span>
+            <div class="candidate-bar-wrap"><div class="candidate-bar"><div class="candidate-bar-fill" style="width:94%"></div></div></div>
+            <span class="candidate-pct">94.2%</span>
+          </div>
+          <div class="candidate-item">
+            <span class="candidate-rank">#2</span>
+            <span class="candidate-name">Гексагональная плотноупакованная (HCP)</span>
+            <div class="candidate-bar-wrap"><div class="candidate-bar"><div class="candidate-bar-fill" style="width:4%"></div></div></div>
+            <span class="candidate-pct">4.1%</span>
+          </div>
+          <div class="candidate-item">
+            <span class="candidate-rank">#3</span>
+            <span class="candidate-name">Кубическая объёмноцентрированная (BCC)</span>
+            <div class="candidate-bar-wrap"><div class="candidate-bar"><div class="candidate-bar-fill" style="width:2%"></div></div></div>
+            <span class="candidate-pct">1.7%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Substance -->
+    <div class="card">
+      <div class="card-header">
+        <span>⚗️</span>
+        <span class="card-title">Распознанное вещество</span>
+      </div>
+      <div class="card-body">
+        <div class="substance-name">Диоксид урана</div>
+        <div class="substance-formula">UO₂ · mp-1305 · COD: 1000040</div>
+        <div class="hazard-badge">⚠ Радиоактивное вещество — соблюдать меры защиты</div>
+        <br>
+        <div class="substance-desc">
+          UO₂ — диоксид урана, химическое соединение урана(IV), обладающее кубической структурой типа флюорита (CaF₂).
+          Твёрдое вещество чёрного цвета с высокой температурой плавления. Основное топливо для ядерных реакторов.
+        </div>
+        <div class="substance-sections">
+          <div class="substance-section">
+            <div class="sec-title">Применение</div>
+            <div class="sec-content">Ядерное топливо в реакторах на тепловых нейтронах, производство MOX-топлива, научные исследования.</div>
+          </div>
+          <div class="substance-section">
+            <div class="sec-title">Свойства ячейки</div>
+            <div class="sec-content">
+              a = b = c = 5.47 Å<br>
+              α = β = γ = 90°<br>
+              V = 163.7 ų
+            </div>
+          </div>
+        </div>
+        <br>
+        <div class="props-grid">
+          <div class="prop-item">
+            <div class="prop-label">Температура плавления</div>
+            <div class="prop-value">2865 °C</div>
+          </div>
+          <div class="prop-item">
+            <div class="prop-label">Плотность</div>
+            <div class="prop-value">10.97 г/см³</div>
+          </div>
+          <div class="prop-item">
+            <div class="prop-label">Молярная масса</div>
+            <div class="prop-value">270.03 г/моль</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Scientific sources -->
+    <div class="card">
+      <div class="card-header">
+        <span>📄</span>
+        <span class="card-title">Научные источники</span>
+        <span style="margin-left:auto;font-size:12px;color:#8b949e;">10 публикаций · CrossRef + OSTI</span>
+      </div>
+      <div class="card-body">
+        <div class="sources-list">
+          <div class="source-item">
+            <div class="source-title">Thermal conductivity of UO2 nuclear fuel — a review <span class="source-tag tag-osti">OSTI</span></div>
+            <div class="source-meta"><span>Journal of Nuclear Materials, 2019</span><span>DOI: 10.1016/j.jnucmat.2019.01.012</span></div>
+            <div class="source-snippet">A comprehensive review of UO2 thermal conductivity data and models, covering irradiation effects and temperature dependence...</div>
+          </div>
+          <div class="source-item">
+            <div class="source-title">Crystal structure of UO2 under high pressure <span class="source-tag tag-crossref">CrossRef</span></div>
+            <div class="source-meta"><span>Physical Review B, 2021</span><span>DOI: 10.1103/PhysRevB.103.054101</span></div>
+            <div class="source-snippet">High-pressure X-ray diffraction study revealing phase transitions in uranium dioxide above 40 GPa...</div>
+          </div>
+          <div class="source-item">
+            <div class="source-title">Defect chemistry of UO2 from first principles <span class="source-tag tag-osti">OSTI</span></div>
+            <div class="source-meta"><span>Physical Review B, 2020</span><span>DOI: 10.1103/PhysRevB.101.184101</span></div>
+            <div class="source-snippet">DFT+U calculations of point defects, migration energies, and their impact on thermal transport...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from cris.core.coordinates import shift_coordinates, normalize_coordinates
 from cris.db.queries import get_similar_xyz_from_db, check_coords
 from cris.db.repository.recognition import get_or_create_session, save_result
 from cris.db.enrichment.substance_enricher import enrich_substance
+from cris.core.ml_predict import predict_catboost, resolve_lattice_ids
 from cris.logger import logger
 from cris.tools.report import save_docx
 
@@ -206,6 +207,29 @@ class MainWindow(QMainWindow):
             logger.info("Session saved: id={} lt_id={} st_id={}", session.id[:8], top_lt_id, top_st_id)
         except Exception as e:
             logger.warning("Could not save recognition session: {}", e)
+
+        # ── CatBoost: записываем ML-предсказания в recognition_result ────────
+        try:
+            cb_preds = predict_catboost(normalized_data)
+            if cb_preds:
+                resolve_lattice_ids(cb_preds)
+                for rank, pred in enumerate(cb_preds, start=1):
+                    save_result(
+                        session_id=session.id,
+                        method="CATBOOST",
+                        method_version="1.0",
+                        rank=rank,
+                        lattice_type_id=pred["lattice_type_id"],
+                        structure_id=None,   # CatBoost предсказывает тип, не конкретную структуру
+                        confidence=pred["confidence"],
+                    )
+                logger.info(
+                    "CatBoost saved: top={} ({:.0f}%)",
+                    cb_preds[0]["class"],
+                    cb_preds[0]["confidence"] * 100,
+                )
+        except Exception as e:
+            logger.warning("CatBoost prediction failed: {}", e)
 
         # ── Запускаем обогащение вещества в фоне (не блокируем UI) ───────────
         if result_possible_substance is not None:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import csv
 import sys
+import threading
 from pathlib import Path
 
 from PySide6.QtCore import Qt
@@ -11,6 +12,9 @@ from cris.app.generated.Ion_Dialog_ui import Ui_Dialog  # Интерфейс д�
 from cris.app.generated.Main_Window_ui import Ui_MainWindow  # Интерфейс главного окна
 from cris.core.coordinates import shift_coordinates, normalize_coordinates
 from cris.db.queries import get_similar_xyz_from_db, check_coords
+from cris.db.repository.recognition import get_or_create_session, save_result
+from cris.db.enrichment.substance_enricher import enrich_substance
+from cris.logger import logger
 from cris.tools.report import save_docx
 
 
@@ -181,6 +185,47 @@ class MainWindow(QMainWindow):
         result_possible_lattice_probability = query_data[1][1]
         result_possible_substance = query_data[2][0]
         result_possible_substance_probability = query_data[2][1]
+
+        # ── Сохраняем сессию распознавания и результат в БД ──────────────────
+        try:
+            norm_tuples = [(row[1], row[2], row[3]) for row in normalized_data]
+            ion_count   = int(self.ui.combo_box_ions.currentText())
+            session = get_or_create_session(ion_count=ion_count, normalized_coords=norm_tuples)
+
+            top_lt_id = result_possible_lattice[0] if result_possible_lattice else None
+            top_st_id = result_possible_substance[0] if result_possible_substance else None
+            save_result(
+                session_id=session.id,
+                method="COORD_MATCH",
+                method_version="1.0",
+                rank=1,
+                lattice_type_id=top_lt_id,
+                structure_id=top_st_id,
+                confidence=round(result_possible_lattice_probability / 100.0, 4),
+            )
+            logger.info("Session saved: id={} lt_id={} st_id={}", session.id[:8], top_lt_id, top_st_id)
+        except Exception as e:
+            logger.warning("Could not save recognition session: {}", e)
+
+        # ── Запускаем обогащение вещества в фоне (не блокируем UI) ───────────
+        if result_possible_substance is not None:
+            st_id      = result_possible_substance[0]
+            st_name    = result_possible_substance[1]
+            st_formula = result_possible_substance[13] if len(result_possible_substance) > 13 else ""
+            lt_name    = str(result_possible_lattice[2]) if result_possible_lattice else ""
+
+            def _bg_enrich():
+                try:
+                    enrich_substance(
+                        structure_id=st_id,
+                        formula=st_formula or st_name,
+                        name=st_name,
+                        lattice_type=lt_name,
+                    )
+                except Exception as exc:
+                    logger.warning("Background substance enrichment failed: {}", exc)
+
+            threading.Thread(target=_bg_enrich, daemon=True).start()
 
         result_lattice_types = " ".join(list(str(item[1]) + " " + f"{item[3]:.2f}%;" for item in result_lattice_types))
         result_substances = " ".join(list(str(item[1]) + " " + f"{item[2]:.2f}%;" for item in result_substances))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ mp-api>=0.41.0
 catboost>=1.2
 requests~=2.32.3
 anthropic~=0.40.0
+gigachat>=0.1.28
 loguru~=0.7.3
 robocrys~=0.2.9
 python-dotenv~=1.1.0


### PR DESCRIPTION
What changed
Remove structure_site table

- Dropped from db_init.sql — table no longer exists in schema
- queries.py rewritten: check_coords() now reads XYZ files directly via reference_structure.xyz_path instead of querying the DB per-ion. Same return format, same tolerance logic.
- repository/structure.py: removed find_matching() which joined on structure_site
- spectrum.py: create_all_spectrum_plots() reads coordinates from XYZ files

download_structures.py now writes to DB

- After saving XYZ, upserts a full row into reference_structure: cell params (a/b/c/α/β/γ/volume), space group (number + HM symbol), lattice_type_id resolved from crystal_system, mp_id, xyz_path (relative to project root), source_url
- Supports --dry-run
- Updates existing rows by mp_id if already present

DB utilities (cris/db/fixes/)

- diagnose.py — full DB state report (lattice types, structures, duplicates, missing xyz_path, substance_info completeness)
- fix_lattice_types.py — corrects wrong lattice type for Fe, W, Al, Cu
- fix_duplicates.py — removes synthetic duplicate structures, reassigns recognition results to COD entries
- load_missing_coords.py — fills xyz_path for structures matched via formula/name keyword mapping