### PR TITLE
feat(chat): add GigaChat AI assistant to workspace

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,11 +1,17 @@
 """
 CRIS — FastAPI backend
-Запуск: uvicorn api:app --reload --port 8000
-Документация: http://localhost:8000/docs
+Запуск: uvicorn backend.api:app --reload --port 8001
+Документация: http://localhost:8001/docs
 """
 
 import hashlib
 import json
+import os
+import sys
+
+from pathlib import Path
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")  # всегда берёт .env из корня проекта
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,6 +21,19 @@ from typing import Optional
 from cris.core.coordinates import shift_coordinates, normalize_coordinates
 from cris.db.connection import get_cursor
 from cris.db.queries import check_coords
+
+# ── GigaChat (опционально) ────────────────────────────────────────────────────
+try:
+    from gigachat import GigaChat
+    from gigachat.models import Chat, Messages, MessagesRole
+    _GIGACHAT_AVAILABLE = True
+except ImportError:
+    _GIGACHAT_AVAILABLE = False
+
+_GC_CREDENTIALS = os.getenv("GIGACHAT_CREDENTIALS", "")
+_GC_SCOPE       = os.getenv("GIGACHAT_SCOPE", "GIGACHAT_API_PERS")
+_GC_MODEL       = os.getenv("GIGACHAT_MODEL", "GigaChat-2-Max")
+_GC_READY       = _GIGACHAT_AVAILABLE and bool(_GC_CREDENTIALS)
 
 # ── Приложение ────────────────────────────────────────────────────────────────
 
@@ -85,6 +104,31 @@ class AnalyzeResponse(BaseModel):
     lattice_ranking: list[RankingItem] = []
 
 
+class ChatMessage(BaseModel):
+    role: str     # "user" | "assistant"
+    content: str
+
+
+class StructureContext(BaseModel):
+    """Контекст текущей структуры — передаётся фронтом после распознавания."""
+    lattice_type:   Optional[str] = None   # например "Кубическая гранецентрированная (FCC)"
+    lattice_en:     Optional[str] = None   # "cubic_f"
+    formula:        Optional[str] = None   # "UN"
+    confidence:     Optional[float] = None # 0.87
+    sg_hm:          Optional[str] = None   # "Fm-3m"
+    ion_count:      Optional[int] = None
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]            # вся история диалога
+    context:  Optional[StructureContext] = None
+
+
+class ChatResponse(BaseModel):
+    reply: str
+    model: str
+
+
 # ── Эндпоинты ─────────────────────────────────────────────────────────────────
 
 def _input_hash(normalized: list) -> str:
@@ -99,6 +143,23 @@ def _input_hash(normalized: list) -> str:
 def health():
     """Проверка — сервер жив."""
     return {"status": "ok", "version": "0.1.0"}
+
+
+@app.get("/api/debug/env")
+def debug_env():
+    """Диагностика — проверить загрузку переменных окружения."""
+    return {
+        "gigachat_available": _GIGACHAT_AVAILABLE,
+        "gigachat_ready":     _GC_READY,
+        "credentials_set":    bool(_GC_CREDENTIALS),
+        "credentials_len":    len(_GC_CREDENTIALS),
+        "scope":              _GC_SCOPE,
+        "model":              _GC_MODEL,
+        "env_file":           str(Path(__file__).parent.parent / ".env"),
+        "env_file_exists":    (Path(__file__).parent.parent / ".env").exists(),
+        "python_executable":  sys.executable,
+        "python_version":     sys.version,
+    }
 
 
 @app.get("/api/stats")
@@ -125,6 +186,77 @@ def stats():
         "lattice_count":  lattice_count,
         "session_count":  session_count,
     }
+
+
+@app.post("/api/chat", response_model=ChatResponse)
+def chat(body: ChatRequest):
+    """
+    Чат с GigaChat в контексте кристаллографического вердикта.
+
+    Фронт передаёт:
+      - messages : полную историю диалога (role=user/assistant)
+      - context  : данные о распознанной структуре (опционально)
+
+    Бэк добавляет системный промпт с контекстом структуры и отправляет в GigaChat.
+    """
+    if not _GC_READY:
+        raise HTTPException(
+            status_code=503,
+            detail="GigaChat недоступен: проверьте GIGACHAT_CREDENTIALS в .env",
+        )
+
+    if not body.messages:
+        raise HTTPException(status_code=400, detail="Список messages пуст")
+
+    # ── Системный промпт ──────────────────────────────────────────
+    system_lines = [
+        "Ты — ИИ-ассистент системы CRIS (Crystal Recognition & Identification System).",
+        "Ты помогаешь учёным и инженерам разбираться в результатах распознавания кристаллических решёток.",
+        "Отвечай научно, кратко и по существу. Используй русский язык.",
+    ]
+
+    ctx = body.context
+    if ctx:
+        system_lines.append("\nТекущая структура, о которой идёт разговор:")
+        if ctx.lattice_type:
+            system_lines.append(f"  • Тип решётки: {ctx.lattice_type}" +
+                                 (f" ({ctx.lattice_en})" if ctx.lattice_en else ""))
+        if ctx.formula:
+            system_lines.append(f"  • Формула: {ctx.formula}")
+        if ctx.confidence is not None:
+            system_lines.append(f"  • Confidence: {ctx.confidence:.2f}")
+        if ctx.sg_hm:
+            system_lines.append(f"  • Пространственная группа: {ctx.sg_hm}")
+        if ctx.ion_count:
+            system_lines.append(f"  • Число ионов: {ctx.ion_count}")
+
+    system_prompt = "\n".join(system_lines)
+
+    # ── Формируем payload для GigaChat ───────────────────────────
+    gc_messages = [Messages(role=MessagesRole.SYSTEM, content=system_prompt)]
+    for m in body.messages:
+        role = MessagesRole.USER if m.role == "user" else MessagesRole.ASSISTANT
+        gc_messages.append(Messages(role=role, content=m.content))
+
+    payload = Chat(
+        model=_GC_MODEL,
+        messages=gc_messages,
+        max_tokens=1024,
+        temperature=0.5,
+    )
+
+    try:
+        with GigaChat(
+            credentials=_GC_CREDENTIALS,
+            scope=_GC_SCOPE,
+            verify_ssl_certs=False,
+        ) as giga:
+            response = giga.chat(payload)
+            reply = response.choices[0].message.content.strip()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"GigaChat error: {e}")
+
+    return ChatResponse(reply=reply, model=_GC_MODEL)
 
 
 @app.post("/api/session")

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -25,9 +25,19 @@ class ErrorBoundary extends React.Component {
   }
 }
 
+const VALID_ROUTES = ["home", "workspace", "about", "docs"];
+
 const App = () => {
-  const [route, setRoute] = React.useState("home");
+  const [route, setRoute] = React.useState(() => {
+    const saved = sessionStorage.getItem("cris_route");
+    return VALID_ROUTES.includes(saved) ? saved : "home";
+  });
   const [anchor, setAnchor] = React.useState(null);
+
+  /* Persist route on every change */
+  React.useEffect(() => {
+    sessionStorage.setItem("cris_route", route);
+  }, [route]);
 
   /* Navigate: change route + optional anchor scroll */
   const navigate = React.useCallback((id, anchorId) => {

--- a/frontend/src/home.jsx
+++ b/frontend/src/home.jsx
@@ -124,7 +124,7 @@ const FeaturesSection = () => {
 };
 
 /* ---------- Description ---------- */
-const API_BASE_HOME = "http://localhost:8001";
+const API_BASE_HOME = "http://localhost:8002";
 
 const DescriptionSection = () => {
   const [liveStats, setLiveStats] = React.useState(null);

--- a/frontend/src/workspace.jsx
+++ b/frontend/src/workspace.jsx
@@ -1,6 +1,6 @@
 /* CRIS — Workspace screen (drag-n-drop, manual input, pipeline, verdict, chat) */
 
-const API_BASE = "http://localhost:8001";
+const API_BASE = "http://localhost:8002";
 
 /* ── Default sample: UN unit cell (NaCl-type FCC, a=4.89Å) ── */
 const DEFAULT_SITES = [
@@ -132,6 +132,18 @@ const WorkspaceScreen = () => {
   const [cell,  setCell]          = React.useState(DEFAULT_CELL);
   const [coordType, setCoordType] = React.useState("frac");
   const screenshotApiRef = React.useRef(null);
+
+  /* Предупреждение при попытке закрыть/перезагрузить страницу */
+  React.useEffect(() => {
+    const isDirty = file !== null || stage === "running" || stage === "result";
+    if (!isDirty) return;
+    const handler = (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [file, stage]);
 
   const start = () => {
     setStage("running");
@@ -577,14 +589,83 @@ const ViewerPipeline = () => (
 /* ============================================================
    RIGHT PANEL — verdict + chat
    ============================================================ */
-const WsRightPanel = ({ stage }) => (
-  <aside style={{ borderLeft: "1px solid var(--hairline)", display: "flex", flexDirection: "column", background: "var(--paper)" }}>
-    <div style={{ padding: 24, flex: "0 0 auto", overflowY: "auto", maxHeight: "62%", borderBottom: "1px solid var(--hairline)" }}>
-      {stage === "result" ? <VerdictBlock /> : <VerdictPlaceholder />}
-    </div>
-    <ChatPanel stage={stage} />
-  </aside>
-);
+/* Mock verdict context — заменить на реальные данные когда ML подключат */
+const MOCK_VERDICT_CONTEXT = {
+  lattice_type: "Кубическая гранецентрированная (FCC)",
+  lattice_en:   "cubic_f",
+  formula:      "UN",
+  confidence:   0.87,
+  sg_hm:        "Fm-3m",
+  ion_count:    8,
+};
+
+const WsRightPanel = ({ stage }) => {
+  const panelRef   = React.useRef(null);
+  const [splitPct, setSplitPct] = React.useState(52); // % высоты под вердикт
+  const dragging   = React.useRef(false);
+
+  const onDividerMouseDown = (e) => {
+    e.preventDefault();
+    dragging.current = true;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+
+    const onMouseMove = (ev) => {
+      if (!dragging.current || !panelRef.current) return;
+      const rect = panelRef.current.getBoundingClientRect();
+      const pct  = ((ev.clientY - rect.top) / rect.height) * 100;
+      setSplitPct(Math.min(Math.max(pct, 20), 78)); // зажимаем 20%–78%
+    };
+
+    const onMouseUp = () => {
+      dragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup",   onMouseUp);
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup",   onMouseUp);
+  };
+
+  return (
+    <aside ref={panelRef} style={{ borderLeft: "1px solid var(--hairline)", display: "flex", flexDirection: "column", background: "var(--paper)", minHeight: 0, overflow: "hidden" }}>
+
+      {/* Блок вердикта — высота задаётся splitPct */}
+      <div style={{ height: `${splitPct}%`, flex: "0 0 auto", overflowY: "auto", minHeight: 0 }}>
+        {stage === "result" ? <VerdictBlock /> : <VerdictPlaceholder />}
+      </div>
+
+      {/* Разделитель */}
+      <div
+        onMouseDown={onDividerMouseDown}
+        style={{
+          flexShrink:  0,
+          height:      6,
+          cursor:      "row-resize",
+          background:  "var(--hairline)",
+          borderTop:   "1px solid var(--hairline)",
+          borderBottom:"1px solid var(--hairline)",
+          display:     "flex",
+          alignItems:  "center",
+          justifyContent: "center",
+          transition:  "background 0.15s",
+        }}
+        onMouseEnter={e => e.currentTarget.style.background = "var(--cobalt-wash)"}
+        onMouseLeave={e => e.currentTarget.style.background = "var(--hairline)"}
+      >
+        {/* три точки-ручка */}
+        <div style={{ display: "flex", gap: 3 }}>
+          {[0,1,2].map(i => <div key={i} style={{ width: 3, height: 3, borderRadius: "50%", background: "var(--mute)" }} />)}
+        </div>
+      </div>
+
+      {/* Чат — занимает остаток */}
+      <ChatPanel stage={stage} context={stage === "result" ? MOCK_VERDICT_CONTEXT : null} />
+    </aside>
+  );
+};
 
 const VerdictPlaceholder = () => (
   <div>
@@ -641,43 +722,168 @@ const VerdictBlock = () => (
   </div>
 );
 
-const ChatPanel = ({ stage }) => {
-  const messages = stage === "result" ? [
-    { role: "system", text: "Спросите про решётку или вещество." },
-    { role: "user",   text: "Почему модель уверенно отнесла к FCC?" },
-    { role: "ai",     text: "KDE-спектр совпал с эталоном UN (Materials Project mp-2731) с расстоянием 0.013 в L2. Random Forest и CatBoost вернули одинаковый top-1 — это согласованное предсказание." },
-  ] : [
-    { role: "system", text: "AI-ассистент включается после распознавания." },
-  ];
+const ChatPanel = ({ stage, context }) => {
+  const [messages, setMessages] = React.useState([]); // [{role:"user"|"assistant", content:""}]
+  const [input,    setInput]    = React.useState("");
+  const [loading,  setLoading]  = React.useState(false);
+  const [error,    setError]    = React.useState(null);
+  const bottomRef = React.useRef(null);
+  const inputRef  = React.useRef(null);
+
+  const active = stage === "result";
+
+  /* Сбрасываем историю когда пользователь запускает новое распознавание */
+  React.useEffect(() => {
+    if (stage === "running") {
+      setMessages([]);
+      setError(null);
+    }
+  }, [stage]);
+
+  /* Автоскролл вниз при каждом новом сообщении */
+  React.useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || loading || !active) return;
+
+    const userMsg = { role: "user", content: text };
+    const history = [...messages, userMsg];
+    setMessages(history);
+    setInput("");
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/chat`, {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: history,
+          context:  context || null,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.detail || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      setMessages(prev => [...prev, { role: "assistant", content: data.reply }]);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
+  };
+
   return (
-    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: 24, minHeight: 0 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 14 }}>
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: 24, minHeight: 0, overflow: "hidden" }}>
+
+      {/* Заголовок */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 14, flexShrink: 0 }}>
         <IconSparkles size={14} />
         <span className="eyebrow" style={{ margin: 0 }}>AI · GigaChat MAX 2</span>
+        {loading && (
+          <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--mute)", fontFamily: "var(--font-mono)" }}>
+            печатает…
+          </span>
+        )}
       </div>
+
+      {/* Лента сообщений */}
       <div style={{ flex: 1, overflowY: "auto", display: "flex", flexDirection: "column", gap: 12, minHeight: 0 }}>
+
+        {/* Заглушка до распознавания */}
+        {!active && (
+          <p style={{ margin: 0, color: "var(--mute)", fontSize: 13, fontStyle: "italic" }}>
+            AI-ассистент включается после распознавания.
+          </p>
+        )}
+
+        {/* Подсказка после вердикта, если диалог пустой */}
+        {active && messages.length === 0 && (
+          <p style={{ margin: 0, color: "var(--mute)", fontSize: 13, fontStyle: "italic" }}>
+            Спросите про решётку, вещество или методы распознавания.
+          </p>
+        )}
+
+        {/* Сообщения */}
         {messages.map((m, i) => (
           <div key={i} style={{
-            alignSelf:   m.role === "user" ? "flex-end" : "flex-start",
-            background:  m.role === "user" ? "var(--cobalt)" : m.role === "ai" ? "var(--card)" : "transparent",
-            color:       m.role === "user" ? "white" : m.role === "system" ? "var(--mute)" : "var(--ink)",
-            border:      m.role === "ai"   ? "1px solid var(--hairline)" : "none",
+            alignSelf:    m.role === "user" ? "flex-end" : "flex-start",
+            background:   m.role === "user" ? "var(--cobalt)" : "var(--card)",
+            color:        m.role === "user" ? "white" : "var(--ink)",
+            border:       m.role === "assistant" ? "1px solid var(--hairline)" : "none",
             borderRadius: 10,
-            padding:      m.role === "system" ? "0" : "10px 14px",
-            fontSize:     m.role === "system" ? 13 : 14,
-            fontStyle:    m.role === "system" ? "italic" : "normal",
-            maxWidth:     m.role === "system" ? "100%" : "85%",
-            lineHeight:   1.5,
-          }}>{m.text}</div>
+            padding:      "10px 14px",
+            fontSize:     14,
+            maxWidth:     "85%",
+            lineHeight:   1.55,
+            whiteSpace:   "pre-wrap",
+          }}>
+            {m.content}
+          </div>
         ))}
+
+        {/* Индикатор загрузки */}
+        {loading && (
+          <div style={{
+            alignSelf: "flex-start", background: "var(--card)",
+            border: "1px solid var(--hairline)", borderRadius: 10,
+            padding: "10px 14px", fontSize: 14, color: "var(--mute)",
+            fontFamily: "var(--font-mono)",
+          }}>
+            ···
+          </div>
+        )}
+
+        {/* Ошибка */}
+        {error && (
+          <div style={{
+            alignSelf: "flex-start", background: "#fff0f0",
+            border: "1px solid #ffc0c0", borderRadius: 10,
+            padding: "10px 14px", fontSize: 13, color: "#c00", maxWidth: "85%",
+          }}>
+            Ошибка: {error}
+          </div>
+        )}
+
+        <div ref={bottomRef} />
       </div>
-      <div style={{ marginTop: 12, display: "flex", gap: 8, alignItems: "center", border: "1px solid var(--hairline-strong)", borderRadius: 6, background: "var(--card)", padding: "4px 4px 4px 12px" }}>
+
+      {/* Поле ввода */}
+      <div style={{
+        marginTop: 12, flexShrink: 0,
+        display: "flex", gap: 8, alignItems: "center",
+        border: `1px solid ${active ? "var(--hairline-strong)" : "var(--hairline)"}`,
+        borderRadius: 6, background: "var(--card)",
+        padding: "4px 4px 4px 12px",
+        opacity: active ? 1 : 0.5,
+      }}>
         <input
-          placeholder={stage === "result" ? "Спросите про вещество…" : "Запустите распознавание"}
-          disabled={stage !== "result"}
+          ref={inputRef}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={active ? "Спросите про вещество… (Enter)" : "Запустите распознавание"}
+          disabled={!active || loading}
           style={{ flex: 1, border: "none", outline: "none", background: "transparent", fontSize: 14, padding: "8px 0" }}
         />
-        <Button variant="primary" size="sm" disabled={stage !== "result"} icon={<IconSend size={14} />} />
+        <Button
+          variant="primary" size="sm"
+          disabled={!active || loading || !input.trim()}
+          icon={<IconSend size={14} />}
+          onClick={send}
+        />
       </div>
     </div>
   );

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ python main.py
 
 ```bash
 # Из корня проекта
-uvicorn backend.api:app --reload --port 8001
+uvicorn backend.api:app --reload --port 8002
 ```
 
 API будет доступно на `http://localhost:8001`.  


### PR DESCRIPTION
- POST /api/chat endpoint: accepts full message history + structure context, builds system prompt and calls GigaChat API
- GET /api/debug/env: diagnostics endpoint for env/credentials check
- GET /api/stats: live counters (structures, lattice types, sessions) for home page
- ChatPanel component in workspace with full conversation history, auto-scroll, Enter-to-send
- WsRightPanel with draggable horizontal splitter between verdict and chat sections
- beforeunload warning when user has loaded data
- Route persistence via sessionStorage across page reloads
- GigaChat config via .env (GIGACHAT_CREDENTIALS, GIGACHAT_SCOPE, GIGACHAT_MODEL)
- Updated readme with web launch instructions