### PR TITLE
feat(ml): integrate Random Forest into /api/analyze pipeline

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -63,6 +63,7 @@ class Ion(BaseModel):
 
 class AnalyzeRequest(BaseModel):
     sites: list[Ion]
+    methods: list[str] = ["db"]   # "db" | "catboost" | "rf"
 
 
 class LatticeResult(BaseModel):
@@ -91,6 +92,14 @@ class RankingItem(BaseModel):
     prob: float
 
 
+class MLMethodResult(BaseModel):
+    method: str                      # "catboost" | "rf"
+    name_en: Optional[str] = None
+    name_ru: Optional[str] = None
+    confidence: float = 0.0
+    ranking: list[RankingItem] = []
+
+
 class AnalyzeResponse(BaseModel):
     success: bool
     message: str = ""
@@ -98,6 +107,7 @@ class AnalyzeResponse(BaseModel):
     lattice: Optional[LatticeResult] = None
     structure: Optional[StructureResult] = None
     lattice_ranking: list[RankingItem] = []
+    ml_results: list[MLMethodResult] = []
 
 
 class ChatMessage(BaseModel):
@@ -240,15 +250,16 @@ def _find_or_create_session(input_hash: str, ion_count: int) -> str:
 
 
 def _save_recognition_result(session_id: str, lattice_type_id: Optional[int],
-                              structure_id: Optional[int], confidence: float):
-    """Сохраняет результат анализа в recognition_result. Метод — GEOMETRIC (поиск по КДЭ-эталонам)."""
+                              structure_id: Optional[int], confidence: float,
+                              method: str = "GEOMETRIC"):
+    """Сохраняет результат анализа в recognition_result."""
     with get_cursor() as cur:
         cur.execute(
             """
             INSERT INTO recognition_result
                 (session_id, method, method_version, rank,
                  predicted_lattice_type_id, predicted_structure_id, confidence)
-            VALUES (%s, 'GEOMETRIC', '1.0', 1, %s, %s, %s)
+            VALUES (%s, %s, '1.0', 1, %s, %s, %s)
             ON CONFLICT (session_id, method, method_version, rank)
             DO UPDATE SET
                 predicted_lattice_type_id = EXCLUDED.predicted_lattice_type_id,
@@ -256,7 +267,7 @@ def _save_recognition_result(session_id: str, lattice_type_id: Optional[int],
                 confidence                = EXCLUDED.confidence,
                 computed_at               = NOW()
             """,
-            (session_id, lattice_type_id, structure_id, confidence)
+            (session_id, method, lattice_type_id, structure_id, confidence)
         )
 
 
@@ -310,6 +321,58 @@ def _load_session_context(session_id: str) -> dict:
             return {}
         cols = [d[0] for d in cur.description]
         return dict(zip(cols, row))
+
+
+def _run_ml_methods(normalized: list, methods: list[str], session_id: Optional[str]) -> list[MLMethodResult]:
+    """
+    Запускает выбранные ML-методы и возвращает список MLMethodResult.
+    Каждый результат также сохраняется в recognition_result.
+    """
+    from cris.core.ml_predict import predict_rf, resolve_lattice_ids
+
+    results: list[MLMethodResult] = []
+
+    def _preds_to_result(method: str, preds: list[dict]) -> MLMethodResult:
+        if not preds:
+            return MLMethodResult(method=method)
+        top = preds[0]
+        # Пробуем взять name_ru для lattice_type_id
+        name_ru = None
+        if top.get("lattice_type_id"):
+            try:
+                with get_cursor() as cur:
+                    cur.execute("SELECT name_ru FROM lattice_type WHERE id=%s", (top["lattice_type_id"],))
+                    row = cur.fetchone()
+                    if row:
+                        name_ru = row[0]
+            except Exception:
+                pass
+        ranking = [
+            RankingItem(name_en=p["lattice_name"], name_ru=None, prob=round(p["confidence"] * 100, 1))
+            for p in preds
+        ]
+        return MLMethodResult(
+            method=method,
+            name_en=top["lattice_name"],
+            name_ru=name_ru,
+            confidence=round(top["confidence"] * 100, 2),
+            ranking=ranking,
+        )
+
+    if "rf" in methods:
+        try:
+            preds = predict_rf(normalized)
+            preds = resolve_lattice_ids(preds)
+            mr = _preds_to_result("rf", preds)
+            results.append(mr)
+            if session_id and preds:
+                _save_recognition_result(session_id, preds[0].get("lattice_type_id"), None,
+                                         mr.confidence, method="RF")
+        except Exception as e:
+            logger.warning("RF inference failed: {}", e)
+            results.append(MLMethodResult(method="rf"))
+
+    return results
 
 
 def _build_system_prompt(ctx: dict) -> str:
@@ -483,11 +546,15 @@ def analyze(body: AnalyzeRequest):
     except Exception:
         session_id = None
 
+    # ── ML методы запускаем всегда, независимо от GEOMETRIC ──
+    ml_results = _run_ml_methods(normalized, body.methods, session_id)
+
     if result is False:
         return AnalyzeResponse(
             success    = False,
             message    = "Совпадающих структур не найдено в эталонной БД",
             session_id = session_id,
+            ml_results = ml_results,
         )
 
     lattice_names, struct_names = result[0]
@@ -514,11 +581,11 @@ def analyze(body: AnalyzeRequest):
         confidence = round(st_prob, 2),
     )
 
-    # ── Сохраняем результат в БД ──────────────────────────────
+    # ── Сохраняем GEOMETRIC результат в БД ───────────────────
     if session_id:
         try:
             _save_recognition_result(
-                session_id    = session_id,
+                session_id      = session_id,
                 lattice_type_id = lattice.id,
                 structure_id    = structure.id,
                 confidence      = lattice.confidence,
@@ -537,6 +604,7 @@ def analyze(body: AnalyzeRequest):
         lattice         = lattice,
         structure       = structure,
         lattice_ranking = ranking,
+        ml_results      = ml_results,
     )
 
 

--- a/cris/core/ml_predict.py
+++ b/cris/core/ml_predict.py
@@ -20,9 +20,10 @@ from scipy.stats import gaussian_kde
 
 from cris.logger import logger
 
-# ── Пути к модели ─────────────────────────────────────────────────────────────
+# ── Пути к моделям ────────────────────────────────────────────────────────────
 _ROOT = Path(__file__).parent.parent.parent
-_DEFAULT_MODEL = _ROOT / "ML" / "CatBoost" / "catboost_lattice.cbm"
+_DEFAULT_MODEL    = _ROOT / "ML" / "CatBoost" / "catboost_lattice.cbm"
+_DEFAULT_RF_MODEL = _ROOT / "ML" / "rf_optimized_model.pkl"
 
 # ── Маппинг классов модели → name_en в таблице lattice_type ──────────────────
 # Модель обучена на подтипах Браве-решётки; все cubic_* → "cubic" и т.д.
@@ -87,7 +88,7 @@ def _coords_to_feature_vector(normalized_coords: list) -> Optional[np.ndarray]:
 
 
 def _load_model(model_path: Path):
-    """Ленивая загрузка модели с понятным сообщением об ошибке."""
+    """Ленивая загрузка CatBoost модели."""
     try:
         from catboost import CatBoostClassifier
         m = CatBoostClassifier()
@@ -98,6 +99,53 @@ def _load_model(model_path: Path):
         return None
     except Exception as e:
         logger.warning("ml_predict: cannot load model {}: {}", model_path, e)
+        return None
+
+
+def _load_sklearn_model(model_path: Path):
+    """Ленивая загрузка sklearn модели через joblib."""
+    try:
+        import joblib
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return joblib.load(str(model_path))
+    except ImportError:
+        logger.warning("ml_predict: joblib not installed")
+        return None
+    except Exception as e:
+        logger.warning("ml_predict: cannot load sklearn model {}: {}", model_path, e)
+        return None
+
+
+def _coords_to_feature_vector_200(normalized_coords: list) -> Optional[np.ndarray]:
+    """
+    Список [label, x, y, z] → усреднённый KDE-вектор 200-dim.
+    Используется для Random Forest (rf_optimized_model.pkl).
+    """
+    try:
+        from cris.core.spectrum import kde_array
+        from cris.core.vectors import get_lattice_vectors3
+
+        _old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            vectors_dict = get_lattice_vectors3(normalized_coords)
+        finally:
+            sys.stdout = _old_stdout
+
+        ion_arrays = []
+        for distances in vectors_dict.values():
+            counter = dict(Counter(distances))
+            if len(counter) >= 2:
+                arr = kde_array(counter)
+                ion_arrays.append(arr)
+
+        if not ion_arrays:
+            return None
+        return np.mean(ion_arrays, axis=0)
+    except Exception as e:
+        logger.warning("ml_predict: failed to compute 200-dim feature vector: {}", e)
         return None
 
 
@@ -154,6 +202,60 @@ def predict_catboost(
         })
 
     logger.debug("CatBoost prediction: top={} conf={}", results[0]["class"], results[0]["confidence"])
+    return results
+
+
+def predict_rf(
+    normalized_coords: list,
+    model_path: Path = _DEFAULT_RF_MODEL,
+    top_k: int = 3,
+) -> list[dict]:
+    """
+    Предсказывает класс через Random Forest (200-dim KDE вектор).
+
+    Args:
+        normalized_coords: список [label, x, y, z] — уже нормализованные
+        model_path:        путь к .pkl файлу
+        top_k:             сколько топ-классов вернуть
+
+    Returns:
+        [{"class": "UC2_phase1", "lattice_name": "UC2_phase1",
+          "lattice_type_id": None, "confidence": 0.52}, ...]
+    """
+    if not model_path.exists():
+        logger.debug("ml_predict: RF model not found: {}", model_path)
+        return []
+
+    model = _load_sklearn_model(model_path)
+    if model is None:
+        return []
+
+    feat = _coords_to_feature_vector_200(normalized_coords)
+    if feat is None:
+        return []
+
+    if len(feat) != model.n_features_in_:
+        logger.warning(
+            "ml_predict: RF feature size mismatch (got {}, need {})",
+            len(feat), model.n_features_in_,
+        )
+        return []
+
+    proba   = model.predict_proba(feat.reshape(1, -1))[0]
+    classes = model.classes_
+
+    top_indices = np.argsort(proba)[::-1][:top_k]
+    results = [
+        {
+            "class":           str(classes[i]),
+            "lattice_name":    _CLASS_TO_LATTICE_EN.get(str(classes[i]), str(classes[i])),
+            "lattice_type_id": None,
+            "confidence":      round(float(proba[i]), 4),
+        }
+        for i in top_indices
+    ]
+
+    logger.debug("RF prediction: top={} conf={}", results[0]["class"], results[0]["confidence"])
     return results
 
 

--- a/frontend/src/workspace.jsx
+++ b/frontend/src/workspace.jsx
@@ -199,7 +199,10 @@ const WorkspaceScreen = ({ setRoute }) => {
     try {
       const res  = await fetch(`${API_BASE}/api/analyze`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sites: cartSites }),
+        body: JSON.stringify({
+          sites: cartSites,
+          methods: Object.entries(methods).filter(([, v]) => v).map(([k]) => k),
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
@@ -608,12 +611,14 @@ const VerdictBlock = ({ result, apiError, siteCount, methods }) => {
     </div>
   );
 
-  const summary   = result?.success ? result.lattice   : null;
-  const structure = result?.success ? result.structure : null;
-  const dbResult  = result?.success ? {
+  const summary        = result?.success ? result.lattice   : null;
+  const structure      = result?.success ? result.structure : null;
+  const dbResult       = result?.success ? {
     name_en: result.lattice?.name_en, name_ru: result.lattice?.name_ru,
     confidence: result.lattice?.confidence, ranking: result.lattice_ranking,
   } : null;
+  const catboostResult = result?.ml_results?.find(r => r.method === "catboost") ?? null;
+  const rfResult       = result?.ml_results?.find(r => r.method === "rf")       ?? null;
 
   return (
     <div>
@@ -652,9 +657,9 @@ const VerdictBlock = ({ result, apiError, siteCount, methods }) => {
       <hr className="hr" style={{ margin: "14px 0" }} />
       {/* [CHANGE 2] WsLabel */}
       <WsLabel>По методам</WsLabel>
-      <MethodResult label="По базе данных" result={dbResult}  active={!!methods?.db} />
-      <MethodResult label="CatBoost"        result={null}      active={!!methods?.catboost} />
-      <MethodResult label="Random Forest"   result={null}      active={!!methods?.rf} />
+      <MethodResult label="По базе данных" result={dbResult}       active={!!methods?.db} />
+      <MethodResult label="CatBoost"        result={catboostResult} active={!!methods?.catboost} />
+      <MethodResult label="Random Forest"   result={rfResult}       active={!!methods?.rf} />
 
       <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
         <Button variant="quiet" size="sm" icon={<IconDownload size={14} />}>JSON</Button>


### PR DESCRIPTION
- Added predict_rf() to cris/core/ml_predict.py using 200-dim KDE vector (rf_optimized_model.pkl, sklearn RandomForestClassifier)
- Added _coords_to_feature_vector_200() — KDE via spectrum.kde_array()
- Added _load_sklearn_model() — joblib loader with version warning suppression
- Added MLMethodResult pydantic model to backend/api.py
- Added methods: list[str] field to AnalyzeRequest ("db" | "rf")
- Added ml_results: list[MLMethodResult] field to AnalyzeResponse
- Added _run_ml_methods() helper — runs selected ML methods, saves each result to recognition_result with method="RF"
- ML methods now run before GEOMETRIC early-return so RF works even when DB matching finds nothing
- frontend: passes methods array in analyze request body
- frontend: reads ml_results from response, wires RF result to MethodResult