### PR TITLE
feat(frontend-ui): AI chat fixes, workspace nav guard, hero visual

### DIFF
--- a/_TEST_ARTYOMA_ASS.py
+++ b/_TEST_ARTYOMA_ASS.py
@@ -1,0 +1,19 @@
+from ase.io import read, write
+
+
+def convert_cif_to_xyz(input_cif, output_xyz):
+    try:
+        # read автоматически парсит CIF, применяет симметрии
+        # и переводит координаты в декартовы (Angstrom)
+        atoms = read(input_cif)
+
+        # write автоматически формирует нужную структуру .xyz файла
+        write(output_xyz, atoms)
+
+        print(f"Конвертация завершена. Найдено атомов: {len(atoms)}")
+    except Exception as e:
+        print(f"Ошибка при конвертации: {e}")
+
+
+# Использование
+convert_cif_to_xyz('NaCl.cif', 'NaCl_Ass_artyom.xyz')

--- a/backend/api.py
+++ b/backend/api.py
@@ -123,6 +123,7 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     session_id: str                 # UUID из /api/analyze
     messages: list[ChatMessage]     # вся история диалога (фронт хранит локально)
+    result_context: Optional[str] = None  # ML-результаты от фронта (когда нет GEOMETRIC)
 
 
 class ChatResponse(BaseModel):
@@ -412,7 +413,7 @@ def _run_ml_methods(normalized: list, methods: list[str], session_id: Optional[s
     return results
 
 
-def _build_system_prompt(ctx: dict) -> str:
+def _build_system_prompt(ctx: dict, result_context: str = None) -> str:
     """Строит системный промпт из данных БД."""
     lines = [
         "Ты — ИИ-ассистент системы CRIS (Crystal Recognition & Identification System).",
@@ -422,6 +423,9 @@ def _build_system_prompt(ctx: dict) -> str:
     ]
 
     if not ctx:
+        if result_context:
+            lines.append("\n═══ РЕЗУЛЬТАТЫ РАСПОЗНАВАНИЯ ═══")
+            lines.append(result_context)
         return "\n".join(lines)
 
     lines.append("\n═══ ТЕКУЩАЯ СТРУКТУРА ═══")
@@ -491,6 +495,12 @@ def _build_system_prompt(ctx: dict) -> str:
                 lines.append("Свойства: " + "; ".join(f"{k}={v}" for k, v in list(props.items())[:6]))
         except Exception:
             pass
+
+    # ML-результаты от фронтенда (CatBoost, RF) — добавляем всегда, если есть
+    if result_context:
+        lines.append("")
+        lines.append("═══ РЕЗУЛЬТАТЫ ML-МЕТОДОВ ═══")
+        lines.append(result_context)
 
     lines.append(
         "\nОтвечай на вопросы пользователя, опираясь на данные выше."
@@ -668,7 +678,7 @@ def chat(body: ChatRequest):
     except Exception:
         ctx = {}
 
-    system_prompt = _build_system_prompt(ctx)
+    system_prompt = _build_system_prompt(ctx, body.result_context)
 
     # ── Формируем payload для GigaChat ───────────────────────
     gc_messages = [Messages(role=MessagesRole.SYSTEM, content=system_prompt)]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,7 +28,7 @@
   <script type="text/babel" src="src/atoms.jsx?v=3"></script>
   <script type="text/babel" src="src/chrome.jsx?v=3"></script>
   <script type="text/babel" src="src/viewer3d.jsx?v=3"></script>
-  <script type="text/babel" src="src/home.jsx?v=13"></script>
+  <script type="text/babel" src="src/home.jsx?v=14"></script>
   <script type="text/babel" src="src/workspace.jsx?v=6"></script>
   <script type="text/babel" src="src/about_docs.jsx?v=11"></script>
   <script type="text/babel" src="src/app.jsx?v=3"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,9 +28,9 @@
   <script type="text/babel" src="src/atoms.jsx?v=3"></script>
   <script type="text/babel" src="src/chrome.jsx?v=3"></script>
   <script type="text/babel" src="src/viewer3d.jsx?v=3"></script>
-  <script type="text/babel" src="src/home.jsx?v=3"></script>
-  <script type="text/babel" src="src/workspace.jsx?v=3"></script>
-  <script type="text/babel" src="src/about_docs.jsx?v=3"></script>
+  <script type="text/babel" src="src/home.jsx?v=12"></script>
+  <script type="text/babel" src="src/workspace.jsx?v=5"></script>
+  <script type="text/babel" src="src/about_docs.jsx?v=11"></script>
   <script type="text/babel" src="src/app.jsx?v=3"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,8 +28,8 @@
   <script type="text/babel" src="src/atoms.jsx?v=3"></script>
   <script type="text/babel" src="src/chrome.jsx?v=3"></script>
   <script type="text/babel" src="src/viewer3d.jsx?v=3"></script>
-  <script type="text/babel" src="src/home.jsx?v=12"></script>
-  <script type="text/babel" src="src/workspace.jsx?v=5"></script>
+  <script type="text/babel" src="src/home.jsx?v=13"></script>
+  <script type="text/babel" src="src/workspace.jsx?v=6"></script>
   <script type="text/babel" src="src/about_docs.jsx?v=11"></script>
   <script type="text/babel" src="src/app.jsx?v=3"></script>
 </body>

--- a/frontend/src/about_docs.jsx
+++ b/frontend/src/about_docs.jsx
@@ -9,20 +9,20 @@ const AboutScreen = () => (
           Как CRIS распознаёт<br />тип решётки.
         </h1>
         <p style={{ fontSize: 18, color: "var(--ink-soft)", lineHeight: 1.55, maxWidth: 680, margin: 0 }}>
-          Четыре независимых метода голосуют параллельно. Их прогнозы объединяются в ансамблевый ранкинг с явной оценкой согласованности.
+          Входные координаты проходят предобработку и преобразуются в числовой дескриптор, который подаётся в три независимых классификатора. Каждый возвращает свой результат с оценкой достоверности.
         </p>
       </div>
     </section>
     <section className="section-tight">
       <div className="container" style={{ maxWidth: 920 }}>
-        <Eyebrow>Методы распознавания</Eyebrow>
+        <Eyebrow>Пайплайн обработки</Eyebrow>
         <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 24 }}>
           {[
-            { n: "01", t: "Нормализация координат", b: "Минимум сдвигается в начало координат, всё делится на глобальный максимум — получаем куб [0, 1]. Это делает совпадение независимым от масштаба и положения ячейки." },
-            { n: "02", t: "KDE-спектр попарных расстояний", b: "Считаем все попарные расстояния между ионами, прогоняем через гауссов KDE. Получаем непрерывный спектр, устойчивый к небольшим шумам и вакансиям." },
-            { n: "03", t: "Random Forest по KDE-вектору", b: "Дискретизованный KDE-вектор подаётся в RF, обученный на 1240+ эталонных структурах (Materials Project + COD). Возвращает дистрибуцию по 8 типам решёток." },
-            { n: "04", t: "CatBoost-классификатор", b: "Параллельная модель на тех же фичах, но с другим деревьями решений. Используется как проверка-голосование: согласие моделей повышает confidence." },
-            { n: "05", t: "Сравнение с эталонной БД", b: "Top-1 предсказание используется для поиска ближайшей реальной структуры в эталонной БД по L2-расстоянию KDE. Возвращает имя вещества и ссылки на COD/MP." },
+            { n: "01", t: "Нормализация координат", b: "Минимальные координаты сдвигаются в начало, затем все значения делятся на глобальный максимум — ячейка приводится к кубу [0, 1]. Результат не зависит от масштаба и ориентации исходной структуры." },
+            { n: "02", t: "Построение KDE-дескриптора", b: "Для каждого типа иона считаются расстояния до всех остальных. Распределение расстояний сглаживается гауссовым KDE на сетке [0, 2] из 200 точек. Векторы по всем типам ионов усредняются в единый 200-мерный дескриптор." },
+            { n: "03", t: "Классификатор Random Forest", b: "200-мерный вектор подаётся в Random Forest, обученный на эталонных структурах соединений урана. Модель возвращает вероятности принадлежности к известным структурным фазам (UC, U₂C₃ и др.)." },
+            { n: "04", t: "Классификатор CatBoost", b: "Тот же дескриптор подаётся в CatBoost — независимую модель на основе градиентного бустинга. Работает параллельно с RF и возвращает собственный ранкинг типов решёток с оценкой достоверности." },
+            { n: "05", t: "Поиск ближайшего эталона в БД", b: "KDE-дескриптор сравнивается с векторами всех эталонных структур в базе по L2-расстоянию. Ближайшее совпадение возвращается как наиболее вероятное реальное соединение с названием вещества и оценкой близости." },
           ].map((m, i) => (
             <Card pad="lg" key={i} style={{ display: "grid", gridTemplateColumns: "60px 1fr", gap: 24, alignItems: "start" }}>
               <div style={{ fontFamily: "var(--font-mono)", fontSize: 12, letterSpacing: ".08em", color: "var(--cobalt)" }}>{m.n}</div>
@@ -37,21 +37,49 @@ const AboutScreen = () => (
     </section>
     <section id="team" className="section" style={{ background: "var(--paper-deep)", borderTop: "1px solid var(--hairline)" }}>
       <div className="container" style={{ maxWidth: 920 }}>
-        <Eyebrow>Подробнее об авторах</Eyebrow>
+        <Eyebrow>Об авторах</Eyebrow>
         <h2 className="section-title" style={{ fontSize: 36, margin: "16px 0 32px", lineHeight: 1.1 }}>Дипломные работы и зоны ответственности</h2>
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
           {[
-            { name: "Артюшин", topic: "«Развитие системы распознавания типов кристаллических решёток с применением методов радиального распределения ближайших соседей и машинного обучения»", area: "ML-инженер · RF / CatBoost · ансамбли · работа с патентом" },
-            { name: "Маркова", topic: "«Внедрение механизмов распознавания типов кристаллических решёток для автоматизации определения методов молекулярно-динамических исследований»", area: "Архитектор БД · поисковик эталонов · интеграция COD / Materials Project" },
-            { name: "Черняков", topic: "«Развитие системы глобального распознавания типов кристаллов с применением методов AI/ML для численного материаловедения»", area: "Backend · собственная нейросеть · 3D-визуализация · математика на numpy" },
+            {
+              name: "Артюшин Артём Александрович",
+              initials: "АА",
+              photo: null,
+              topic: "«Разработка алгоритмов для системы распознавания типов кристаллических решёток с использованием ядерной оценки плотности радиального распределения и машинного обучения»",
+              area: "Математическое и алгоритмическое обоснование метода идентификации · радиальная функция распределения · ядерная оценка плотности · классификатор Random Forest · обучение моделей машинного обучения",
+            },
+            {
+              name: "Маркова Алёна Денисовна",
+              initials: "МА",
+              photo: "assets/team/markova.jpg",
+              topic: "«Разработка программной архитектуры информационной системы CRIS для автоматизированной идентификации типов кристаллических решёток»",
+              area: "Программная архитектура комплекса · серверная часть · веб-клиент · эталонная база данных · встраиваемая программная библиотека",
+            },
+            {
+              name: "Черняков Матвей Сергеевич",
+              initials: "ЧМ",
+              photo: "assets/team/chernyakov.jpg",
+              topic: "«Проектирование и внедрение RAG-системы с применением AI/ML-механизмов в программный комплекс CRIS»",
+              area: "Подсистема AI/ML-механизмов · RAG-обогащение метаданных · диалоговый ИИ-помощник · формирование обучающего датасета · классификатор CatBoost",
+            },
           ].map((a, i) => (
             <Card pad="lg" key={i}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
-                <h3 className="section-title" style={{ fontSize: 22, margin: 0 }}>{a.name}</h3>
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--mute)" }}>diploma · 2026</span>
+              <div style={{ display: "flex", gap: 20, alignItems: "flex-start" }}>
+                <div style={{ flexShrink: 0 }}>
+                  {a.photo
+                    ? <img src={a.photo} alt={a.name} style={{ width: 100, height: 100, borderRadius: "50%", objectFit: "cover", objectPosition: "top center", display: "block" }} />
+                    : <div style={{ width: 100, height: 100, borderRadius: "50%", background: "var(--ink)", color: "var(--paper)", display: "grid", placeItems: "center", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 24, letterSpacing: ".02em" }}>{a.initials}</div>
+                  }
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+                    <h3 className="section-title" style={{ fontSize: 20, margin: 0 }}>{a.name}</h3>
+                    <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--mute)", whiteSpace: "nowrap" }}>diploma · 2026</span>
+                  </div>
+                  <p style={{ margin: "8px 0 0", fontSize: 14, color: "var(--ink-soft)", lineHeight: 1.55, fontStyle: "italic" }}>{a.topic}</p>
+                  <div style={{ marginTop: 10, fontSize: 13, color: "var(--cobalt-deep)", fontFamily: "var(--font-mono)" }}>{a.area}</div>
+                </div>
               </div>
-              <p style={{ margin: "10px 0 0", fontSize: 14, color: "var(--ink-soft)", lineHeight: 1.55 }}>{a.topic}</p>
-              <div style={{ marginTop: 12, fontSize: 13, color: "var(--cobalt-deep)", fontFamily: "var(--font-mono)" }}>{a.area}</div>
             </Card>
           ))}
         </div>

--- a/frontend/src/chrome.jsx
+++ b/frontend/src/chrome.jsx
@@ -106,7 +106,7 @@ const Footer = ({ setRoute }) => (
     </div>
     <div className="container" style={{ marginTop: 48, paddingTop: 24, borderTop: "1px solid var(--night-line)", display: "flex", justifyContent: "space-between", color: "var(--night-mute)", fontFamily: "var(--font-mono)", fontSize: 12, letterSpacing: ".04em" }}>
       <span>© 2026 CRIS · MIT licence</span>
-      <span>build 2026.05.12 · v0.4.1</span>
+      <span>build 2026.05.12 · v0.4.3</span>
     </div>
   </footer>
 );

--- a/frontend/src/home.jsx
+++ b/frontend/src/home.jsx
@@ -51,71 +51,41 @@ const HeroVisual = () => (
       <LatticeDiagram size={250} />
     </div>
     <div style={{ position: "relative", borderTop: "1px solid var(--night-line)", paddingTop: 14, marginTop: 8, display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--night-mute)" }}>
-      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>тип</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>FCC · кубическая ГЦК</div></div>
       <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>совпадение</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>UN · mp-2731</div></div>
+      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>сингония</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>FCC · кубическая</div></div>
       <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>уверенность</div><div style={{ color: "var(--signal)", fontSize: 13 }}>0.87</div></div>
     </div>
   </div>
 );
 
 const LatticeDiagram = ({ size = 220, animated = true }) => {
-  // FCC unit cell: 8 corners + 6 face-centre atoms
+  // 2x2x2 isometric lattice
+  const nodes = [];
+  for (let z = 0; z < 2; z++) for (let y = 0; y < 2; y++) for (let x = 0; x < 2; x++) {
+    nodes.push([x, y, z]);
+  }
   const project = ([x, y, z]) => {
     const sx = (x - z) * 60 + size / 2;
     const sy = (x + z) * 30 + y * -60 + size / 2 + 30;
     return [sx, sy];
   };
-
-  // Corners of the unit cell
-  const corners = [];
-  for (let z = 0; z < 2; z++) for (let y = 0; y < 2; y++) for (let x = 0; x < 2; x++) {
-    corners.push([x, y, z]);
-  }
-
-  // 6 face-centre atoms (FCC positions)
-  const faceCentres = [
-    [0.5, 0.5, 0],   // top face
-    [0.5, 0.5, 1],   // bottom face
-    [0.5, 0,   0.5], // front face
-    [0.5, 1,   0.5], // back face
-    [0,   0.5, 0.5], // left face
-    [1,   0.5, 0.5], // right face
-  ];
-
-  // Cube-frame edges (corners only, for a clean outline)
   const edges = [];
-  for (let i = 0; i < corners.length; i++) for (let j = i + 1; j < corners.length; j++) {
-    const [a, b, c] = corners[i], [d, e, f] = corners[j];
-    if (Math.abs(a - d) + Math.abs(b - e) + Math.abs(c - f) === 1) edges.push([corners[i], corners[j]]);
+  for (let i = 0; i < nodes.length; i++) for (let j = i + 1; j < nodes.length; j++) {
+    const [a, b, c] = nodes[i], [d, e, f] = nodes[j];
+    if (Math.abs(a - d) + Math.abs(b - e) + Math.abs(c - f) === 1) edges.push([nodes[i], nodes[j]]);
   }
-
-  // Index 0 → (0.5,0.5,0) — top face centre is the "detected" highlighted atom
-  const highlightIdx = 0;
-
   return (
     <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
-      {/* Cube-frame edges */}
       {edges.map(([n1, n2], i) => {
         const [x1, y1] = project(n1), [x2, y2] = project(n2);
-        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255,255,255,0.28)" strokeWidth="1" />;
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255,255,255,0.32)" strokeWidth="1" />;
       })}
-      {/* Corner atoms — cobalt blue */}
-      {corners.map((n, i) => {
+      {nodes.map((n, i) => {
         const [cx, cy] = project(n);
+        const highlight = i === 5;
         return (
-          <circle key={`c${i}`} cx={cx} cy={cy} r={5}
-                  fill="var(--cobalt)"
-                  stroke="rgba(255,255,255,0.4)"
-                  strokeWidth="1.5" />
-        );
-      })}
-      {/* Face-centre atoms — slightly lighter, one pulsing green */}
-      {faceCentres.map((n, i) => {
-        const [cx, cy] = project(n);
-        const highlight = i === highlightIdx;
-        return (
-          <circle key={`f${i}`} cx={cx} cy={cy} r={highlight ? 7 : 5}
-                  fill={highlight ? "var(--signal)" : "rgba(100,140,255,0.9)"}
+          <circle key={i} cx={cx} cy={cy} r={highlight ? 7 : 5}
+                  fill={highlight ? "var(--signal)" : "var(--cobalt)"}
                   stroke={highlight ? "var(--signal)" : "rgba(255,255,255,0.4)"}
                   strokeWidth="1.5"
                   style={animated && highlight ? { animation: "node-pulse 1.6s ease-in-out infinite" } : {}} />

--- a/frontend/src/home.jsx
+++ b/frontend/src/home.jsx
@@ -15,7 +15,7 @@ const Hero = ({ setRoute }) => (
   <section className="bg-lattice" style={{ paddingTop: 96, paddingBottom: 120, borderBottom: "1px solid var(--hairline)" }}>
     <div className="container" style={{ display: "grid", gridTemplateColumns: "1.1fr 0.9fr", gap: 64, alignItems: "center" }}>
       <div>
-        <Eyebrow>Crystal recognition · v0.4.1</Eyebrow>
+        <Eyebrow>Crystal recognition · v0.4.3</Eyebrow>
         <h1 className="section-title" style={{ fontSize: 72, lineHeight: 1.02, margin: "20px 0 24px", letterSpacing: "-0.025em" }}>
           Определяем тип<br />кристаллической<br />решётки<span style={{ color: "var(--cobalt)" }}>.</span>
         </h1>
@@ -47,8 +47,8 @@ const HeroVisual = () => (
       <span>3d viewer · live</span>
       <span style={{ color: "var(--signal)" }}>● matched</span>
     </div>
-    <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center", height: 240 }}>
-      <LatticeDiagram size={220} />
+    <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center", height: 270 }}>
+      <LatticeDiagram size={250} />
     </div>
     <div style={{ position: "relative", borderTop: "1px solid var(--night-line)", paddingTop: 14, marginTop: 8, display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--night-mute)" }}>
       <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>type</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>cubic_f · FCC</div></div>
@@ -98,10 +98,10 @@ const LatticeDiagram = ({ size = 220, animated = true }) => {
 /* ---------- Features ---------- */
 const FeaturesSection = () => {
   const features = [
-    { eyebrow: "01 · INPUT", title: "Любой источник данных", body: "CIF, XYZ или ручной ввод координат. Поддерживаются макроструктуры до 1000 ионов, нормализация решётки в куб [0, 2] проходит автоматически." },
+    { eyebrow: "01 · INPUT", title: "Любой источник данных", body: "CIF, XYZ или ручной ввод координат. Поддерживаются макроструктуры до 1000 ионов, нормализация координат в куб [0, 1] проходит автоматически." },
     { eyebrow: "02 · METHOD", title: "Ансамбль методов, не один", body: "Random Forest, CatBoost и поиск по внутренней базе данных работают параллельно. Доступны ранжирование и достоверность по каждому методу." },
     { eyebrow: "03 · VERDICT", title: "Не только тип, но и структура", body: "Кроме типа кристаллической решётки, система возвращает наиболее вероятную эталонную структуру и ссылки на эталоны в COD и Materials Project." },
-    { eyebrow: "04 · ASK", title: "AI-ассистент в контексте анализа", body: "GigaChat MAX 2 знает базу CRIS и научные источники. Спросите про вещество, метод или интерпретацию результата." },
+    { eyebrow: "04 · ASK", title: "AI-ассистент в контексте анализа", body: "GigaChat-2-Max отвечает на вопросы в контексте сессии. Спросите про вещество, метод или интерпретацию результата." },
     { eyebrow: "05 · 3D", title: "Удобная визуализация", body: "Интерактивная 3D-сцена элементарной ячейки с возможностью вращения и масштабирования прямо в браузере." },
     { eyebrow: "06 · EMBED", title: "Встраиваемая библиотека", body: "Тот же ансамбль доступен как пакет `cris-core`. REST API и Python SDK работают с теми же эталонами." },
   ];
@@ -178,9 +178,9 @@ const DescriptionSection = () => {
 /* ---------- Team ---------- */
 const TeamSection = () => {
   const team = [
-    { initials: "АА", name: "Артюшин", role: "ML-инженер · радиальное распределение, ансамбли" },
-    { initials: "МА", name: "Маркова",  role: "Архитектор БД · поисковик эталонов, COD/MP" },
-    { initials: "ЧЕ", name: "Черняков", role: "Backend + 3D · нейросеть, визуализация, материаловедение" },
+    { initials: "АА", photo: null,                        name: "Артюшин Артём",   role: "Математическое и алгоритмическое обоснование · РФР · KDE · Random Forest" },
+    { initials: "МА", photo: "assets/team/markova.jpg",   name: "Маркова Алёна",   role: "Программная архитектура · серверная часть · веб-клиент · БД · библиотека" },
+    { initials: "ЧМ", photo: "assets/team/chernyakov.jpg",name: "Черняков Матвей", role: "AI/ML-механизмы · RAG · ИИ-ассистент · датасет · CatBoost" },
   ];
   return (
     <section className="section">
@@ -189,7 +189,10 @@ const TeamSection = () => {
         <div style={{ marginTop: 48, display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 24 }}>
           {team.map((t, i) => (
             <Card pad="lg" key={i}>
-              <div style={{ width: 56, height: 56, borderRadius: 999, background: "var(--ink)", color: "var(--paper)", display: "grid", placeItems: "center", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 16, letterSpacing: ".02em" }}>{t.initials}</div>
+              {t.photo
+                ? <img src={t.photo} alt={t.name} style={{ width: 96, height: 96, borderRadius: "50%", objectFit: "cover", objectPosition: "top center", display: "block" }} />
+                : <div style={{ width: 96, height: 96, borderRadius: 999, background: "var(--ink)", color: "var(--paper)", display: "grid", placeItems: "center", fontFamily: "var(--font-mono)", fontWeight: 600, fontSize: 22, letterSpacing: ".02em" }}>{t.initials}</div>
+              }
               <div style={{ marginTop: 20, fontFamily: "var(--font-display)", fontSize: 22, fontWeight: 500, color: "var(--ink)" }}>{t.name}</div>
               <div style={{ marginTop: 6, fontSize: 14, color: "var(--ink-soft)", lineHeight: 1.5 }}>{t.role}</div>
             </Card>

--- a/frontend/src/home.jsx
+++ b/frontend/src/home.jsx
@@ -45,47 +45,77 @@ const HeroVisual = () => (
     <div style={{ position: "absolute", inset: 0, backgroundImage: "radial-gradient(circle at 30% 25%, rgba(37,64,255,0.22), transparent 55%), radial-gradient(circle at 70% 80%, rgba(220,255,58,0.12), transparent 55%)" }} />
     <div style={{ position: "relative", display: "flex", justifyContent: "space-between", color: "var(--night-mute)", fontFamily: "var(--font-mono)", fontSize: 11, letterSpacing: ".08em", textTransform: "uppercase" }}>
       <span>3d viewer · live</span>
-      <span style={{ color: "var(--signal)" }}>● matched</span>
+      <span style={{ color: "var(--signal)" }}>● распознано</span>
     </div>
     <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center", height: 270 }}>
       <LatticeDiagram size={250} />
     </div>
     <div style={{ position: "relative", borderTop: "1px solid var(--night-line)", paddingTop: 14, marginTop: 8, display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--night-mute)" }}>
-      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>type</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>cubic_f · FCC</div></div>
-      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>match</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>UN · mp-2731</div></div>
-      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>conf.</div><div style={{ color: "var(--signal)", fontSize: 13 }}>0.87</div></div>
+      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>тип</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>FCC · кубическая ГЦК</div></div>
+      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>совпадение</div><div style={{ color: "var(--night-ink)", fontSize: 13 }}>UN · mp-2731</div></div>
+      <div><div style={{ textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 2 }}>уверенность</div><div style={{ color: "var(--signal)", fontSize: 13 }}>0.87</div></div>
     </div>
   </div>
 );
 
 const LatticeDiagram = ({ size = 220, animated = true }) => {
-  // 2x2x2 FCC-ish isometric lattice
-  const nodes = [];
-  for (let z = 0; z < 2; z++) for (let y = 0; y < 2; y++) for (let x = 0; x < 2; x++) {
-    nodes.push([x, y, z]);
-  }
+  // FCC unit cell: 8 corners + 6 face-centre atoms
   const project = ([x, y, z]) => {
     const sx = (x - z) * 60 + size / 2;
     const sy = (x + z) * 30 + y * -60 + size / 2 + 30;
     return [sx, sy];
   };
-  const edges = [];
-  for (let i = 0; i < nodes.length; i++) for (let j = i + 1; j < nodes.length; j++) {
-    const [a, b, c] = nodes[i], [d, e, f] = nodes[j];
-    if (Math.abs(a - d) + Math.abs(b - e) + Math.abs(c - f) === 1) edges.push([nodes[i], nodes[j]]);
+
+  // Corners of the unit cell
+  const corners = [];
+  for (let z = 0; z < 2; z++) for (let y = 0; y < 2; y++) for (let x = 0; x < 2; x++) {
+    corners.push([x, y, z]);
   }
+
+  // 6 face-centre atoms (FCC positions)
+  const faceCentres = [
+    [0.5, 0.5, 0],   // top face
+    [0.5, 0.5, 1],   // bottom face
+    [0.5, 0,   0.5], // front face
+    [0.5, 1,   0.5], // back face
+    [0,   0.5, 0.5], // left face
+    [1,   0.5, 0.5], // right face
+  ];
+
+  // Cube-frame edges (corners only, for a clean outline)
+  const edges = [];
+  for (let i = 0; i < corners.length; i++) for (let j = i + 1; j < corners.length; j++) {
+    const [a, b, c] = corners[i], [d, e, f] = corners[j];
+    if (Math.abs(a - d) + Math.abs(b - e) + Math.abs(c - f) === 1) edges.push([corners[i], corners[j]]);
+  }
+
+  // Index 0 → (0.5,0.5,0) — top face centre is the "detected" highlighted atom
+  const highlightIdx = 0;
+
   return (
     <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      {/* Cube-frame edges */}
       {edges.map(([n1, n2], i) => {
         const [x1, y1] = project(n1), [x2, y2] = project(n2);
-        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255,255,255,0.32)" strokeWidth="1" />;
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255,255,255,0.28)" strokeWidth="1" />;
       })}
-      {nodes.map((n, i) => {
+      {/* Corner atoms — cobalt blue */}
+      {corners.map((n, i) => {
         const [cx, cy] = project(n);
-        const highlight = i === 5;
         return (
-          <circle key={i} cx={cx} cy={cy} r={highlight ? 7 : 5}
-                  fill={highlight ? "var(--signal)" : "var(--cobalt)"}
+          <circle key={`c${i}`} cx={cx} cy={cy} r={5}
+                  fill="var(--cobalt)"
+                  stroke="rgba(255,255,255,0.4)"
+                  strokeWidth="1.5" />
+        );
+      })}
+      {/* Face-centre atoms — slightly lighter, one pulsing green */}
+      {faceCentres.map((n, i) => {
+        const [cx, cy] = project(n);
+        const highlight = i === highlightIdx;
+        return (
+          <circle key={`f${i}`} cx={cx} cy={cy} r={highlight ? 7 : 5}
+                  fill={highlight ? "var(--signal)" : "rgba(100,140,255,0.9)"}
                   stroke={highlight ? "var(--signal)" : "rgba(255,255,255,0.4)"}
                   strokeWidth="1.5"
                   style={animated && highlight ? { animation: "node-pulse 1.6s ease-in-out infinite" } : {}} />

--- a/frontend/src/workspace.jsx
+++ b/frontend/src/workspace.jsx
@@ -120,6 +120,12 @@ const WorkspaceHeader = ({ stage, result, file, onReset, setRoute }) => {
     ? { dot: "var(--signal)", label: "computing", color: "var(--signal)", pulse: true }
     : { dot: "rgba(255,255,255,0.22)", label: "idle", color: "rgba(255,255,255,0.35)" };
 
+  const handleGoHome = () => {
+    const isDirty = file !== null || stage === "running" || stage === "result";
+    if (isDirty && !window.confirm("Данные текущего анализа не сохранятся.\nВыйти из Workspace?")) return;
+    setRoute?.("home");
+  };
+
   return (
     <header style={{
       height: 56, background: "var(--ink)",
@@ -127,8 +133,8 @@ const WorkspaceHeader = ({ stage, result, file, onReset, setRoute }) => {
       display: "flex", alignItems: "center",
       padding: "0 20px", gap: 16, flexShrink: 0, zIndex: 50,
     }}>
-      {/* Logo — click to go home */}
-      <div onClick={() => setRoute?.("home")} style={{ cursor: "pointer", display: "flex", alignItems: "center", gap: 8, userSelect: "none" }}>
+      {/* Logo — click to go home (with dirty-check confirmation) */}
+      <div onClick={handleGoHome} style={{ cursor: "pointer", display: "flex", alignItems: "center", gap: 8, userSelect: "none" }}>
         <Logo size={24} color="var(--night-ink)" node="var(--signal)" />
         <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, fontSize: 17, letterSpacing: "-0.015em", color: "var(--night-ink)" }}>CRIS</span>
       </div>

--- a/frontend/src/workspace.jsx
+++ b/frontend/src/workspace.jsx
@@ -505,10 +505,16 @@ const ViewerPipeline = () => (
    [CHANGE 3] RIGHT PANEL — tab switcher replaces draggable divider.
    ══════════════════════════════════════════════════════════ */
 const WsRightPanel = ({ stage, result, apiError, siteCount, methods, sessionId, section, setSection }) => {
-  const [tab, setTab] = React.useState("verdict");
+  const [tab, setTab]                   = React.useState("verdict");
+  const [chatMessages, setChatMessages] = React.useState([]);
 
   React.useEffect(() => {
     if (stage === "result") setTab("verdict");
+  }, [stage]);
+
+  // Сбрасываем историю чата при каждом новом анализе
+  React.useEffect(() => {
+    if (stage === "running") setChatMessages([]);
   }, [stage]);
 
   return (
@@ -532,16 +538,23 @@ const WsRightPanel = ({ stage, result, apiError, siteCount, methods, sessionId, 
         ))}
       </div>
 
-      {/* Content */}
-      {tab === "verdict" ? (
-        <div style={{ flex: 1, overflowY: "auto", padding: 24, minHeight: 0 }}>
-          {stage === "result"
-            ? <VerdictBlock result={result} apiError={apiError} siteCount={siteCount} methods={methods} section={section} setSection={setSection} />
-            : <VerdictPlaceholder />}
-        </div>
-      ) : (
-        <ChatPanel stage={stage} sessionId={sessionId} />
-      )}
+      {/* Verdict — всегда в DOM, скрываем через display */}
+      <div style={{ display: tab === "verdict" ? "flex" : "none", flex: 1, overflowY: "auto", padding: 24, minHeight: 0, flexDirection: "column" }}>
+        {stage === "result"
+          ? <VerdictBlock result={result} apiError={apiError} siteCount={siteCount} methods={methods} section={section} setSection={setSection} />
+          : <VerdictPlaceholder />}
+      </div>
+
+      {/* Chat — всегда в DOM, история не теряется при смене таба */}
+      <div style={{ display: tab === "chat" ? "flex" : "none", flex: 1, flexDirection: "column", minHeight: 0, overflow: "hidden" }}>
+        <ChatPanel
+          stage={stage}
+          sessionId={sessionId}
+          result={result}
+          messages={chatMessages}
+          setMessages={setChatMessages}
+        />
+      </div>
     </aside>
   );
 };
@@ -565,7 +578,7 @@ const RankingRow = ({ item, top }) => (
   </div>
 );
 
-const MethodResult = ({ label, result, active }) => (
+const MethodResult = ({ label, result, active, emptyText = "Нет данных" }) => (
   <div style={{ border: `1px solid ${active && result ? "var(--cobalt)" : "var(--hairline)"}`, borderRadius: 8, padding: "12px 14px", marginTop: 10 }}>
     <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
       <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, letterSpacing: ".06em", textTransform: "uppercase", color: "var(--mute)" }}>{label}</span>
@@ -586,7 +599,7 @@ const MethodResult = ({ label, result, active }) => (
         )}
       </>
     ) : active ? (
-      <div style={{ fontSize: 12, color: "var(--mute)" }}>Метод будет подключён позже</div>
+      <div style={{ fontSize: 12, color: "var(--mute)" }}>{emptyText}</div>
     ) : null}
   </div>
 );
@@ -711,8 +724,8 @@ const VerdictBlock = ({ result, apiError, siteCount, methods, section, setSectio
           ) : (
             <p style={{ marginTop: 4, color: "var(--mute)", fontSize: 14 }}>{result?.message || "Совпадений в базе не найдено"}</p>
           )}
-          <MethodResult label="По базе данных"      result={dbLatticeResult}  active={!!methods?.db} />
-          <MethodResult label="CatBoost · сингония" result={catboostResult}   active={!!methods?.catboost} />
+          <MethodResult label="По базе данных"      result={dbLatticeResult}  active={!!methods?.db}       emptyText="Нет совпадений в базе данных" />
+          <MethodResult label="CatBoost · сингония" result={catboostResult}   active={!!methods?.catboost} emptyText="Нет данных от модели" />
         </div>
       )}
 
@@ -727,9 +740,9 @@ const VerdictBlock = ({ result, apiError, siteCount, methods, section, setSectio
           ) : (
             <p style={{ marginTop: 4, color: "var(--mute)", fontSize: 14 }}>{result?.message || "Совпадений в базе не найдено"}</p>
           )}
-          <MethodResult label="По базе данных"      result={dbSubstanceResult}      active={!!methods?.db} />
-          <MethodResult label="CatBoost · вещество" result={catboostSubstanceResult} active={!!methods?.catboost_substance} />
-          <MethodResult label="Random Forest"        result={rfResult}                active={!!methods?.rf} />
+          <MethodResult label="По базе данных"      result={dbSubstanceResult}      active={!!methods?.db}                  emptyText="Нет совпадений в базе данных" />
+          <MethodResult label="CatBoost · вещество" result={catboostSubstanceResult} active={!!methods?.catboost_substance}  emptyText="Нет данных от модели" />
+          <MethodResult label="Random Forest"        result={rfResult}                active={!!methods?.rf}                  emptyText="Нет данных от модели" />
         </div>
       )}
 
@@ -816,22 +829,39 @@ const renderWithLatex = (text) => {
 };
 
 /* ── Chat ── */
-const ChatPanel = ({ stage, sessionId }) => {
-  const [messages, setMessages] = React.useState([]);
-  const [input,    setInput]    = React.useState("");
-  const [loading,  setLoading]  = React.useState(false);
-  const [error,    setError]    = React.useState(null);
+const ChatPanel = ({ stage, sessionId, result, messages, setMessages }) => {
+  const [input,   setInput]   = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [error,   setError]   = React.useState(null);
   const bottomRef = React.useRef(null);
   const inputRef  = React.useRef(null);
   const active    = stage === "result" && !!sessionId;
 
   React.useEffect(() => {
-    if (stage === "running") { setMessages([]); setError(null); }
+    if (stage === "running") setError(null);
   }, [stage]);
 
   React.useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: "nearest" });
   }, [messages, loading]);
+
+  // Строим строку с ML-результатами для системного промпта (Bug 2 fix)
+  const buildResultContext = () => {
+    if (!result) return null;
+    const parts = [];
+    const ml = result.ml_results || [];
+    if (result.success && result.structure?.name) {
+      parts.push(`База данных: ${result.structure.name}`);
+      if (result.lattice?.name_en) parts.push(`Тип решётки (DB): ${result.lattice.name_en}`);
+    }
+    const cbSubst = ml.find(r => r.method === "catboost_substance");
+    if (cbSubst?.name_en) parts.push(`CatBoost-вещество: ${cbSubst.name_en} (${cbSubst.confidence?.toFixed(1)}%)`);
+    const rf = ml.find(r => r.method === "rf");
+    if (rf?.name_en) parts.push(`Random Forest: ${rf.name_en} (${rf.confidence?.toFixed(1)}%)`);
+    const cbSyng = ml.find(r => r.method === "catboost");
+    if (cbSyng?.name_en) parts.push(`CatBoost-сингония: ${cbSyng.name_en} (${cbSyng.confidence?.toFixed(1)}%)`);
+    return parts.length ? parts.join("\n") : null;
+  };
 
   const send = async () => {
     const text = input.trim();
@@ -842,7 +872,11 @@ const ChatPanel = ({ stage, sessionId }) => {
     try {
       const res = await fetch(`${API_BASE}/api/chat`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ session_id: sessionId, messages: history }),
+        body: JSON.stringify({
+          session_id: sessionId,
+          messages: history,
+          result_context: buildResultContext() || undefined,
+        }),
       });
       if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.detail || `HTTP ${res.status}`); }
       const data = await res.json();


### PR DESCRIPTION
## Summary
- **AI чат**: история переписки больше не теряется при переключении вкладок Результат ↔ AI·Чат (подъём состояния + CSS display:none вместо unmount)
- **AI контекст**: ИИ теперь видит результаты распознавания — фронт отправляет result_context (DB + CatBoost + RF) с каждым сообщением; бэкенд включает их в системный промпт в обоих случаях (с DB-совпадением и без)
- **Workspace**: при клике на логотип CRIS появляется confirm-диалог если есть несохранённые данные (аналогично beforeunload)
- **Карточки методов**: убрана надпись «Метод будет подключён позже» — теперь «Нет совпадений в базе данных» / «Нет данных от модели»
- **Главная страница**: порядок плашек в hero-карточке — совпадение → сингония → уверенность; `● распознано` вместо `● matched`
## Test plan
- [ ] Запустить анализ, написать в AI-чат, перейти в «Результат» и обратно — история должна сохраниться
- [ ] Убедиться что ИИ упоминает найденное вещество/тип решётки в ответах
- [ ] Загрузить файл, кликнуть лого CRIS — должен появиться confirm; при отмене остаться в workspace
- [ ] На главной странице проверить порядок: совпадение → сингония → уверенность